### PR TITLE
JBIDE-26816: Update bundles ids of the Quarkus plugins/feature to org.jboss.tools.quarkus.* - Change the maven group id of the tests to 'org.jboss.tools.quarkus.test'

### DIFF
--- a/test/org.jboss.tools.quarkus.bot.test/pom.xml
+++ b/test/org.jboss.tools.quarkus.bot.test/pom.xml
@@ -22,12 +22,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.quarkus.eclipse</groupId>
+        <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>test</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>io.quarkus.eclipse.test</groupId>
+    <groupId>org.jboss.tools.quarkus.test</groupId>
     <artifactId>org.jboss.tools.quarkus.bot.test</artifactId>
     
     <packaging>eclipse-test-plugin</packaging>

--- a/test/org.jboss.tools.quarkus.core.test/pom.xml
+++ b/test/org.jboss.tools.quarkus.core.test/pom.xml
@@ -22,12 +22,12 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>io.quarkus.eclipse</groupId>
+        <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>test</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>io.quarkus.eclipse.test</groupId>
+    <groupId>org.jboss.tools.quarkus.test</groupId>
     <artifactId>org.jboss.tools.quarkus.core.test</artifactId>
 
     <packaging>eclipse-test-plugin</packaging>

--- a/test/org.jboss.tools.quarkus.runtime.test/pom.xml
+++ b/test/org.jboss.tools.quarkus.runtime.test/pom.xml
@@ -22,12 +22,12 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>io.quarkus.eclipse</groupId>
+        <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>test</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>io.quarkus.eclipse.test</groupId>
+    <groupId>org.jboss.tools.quarkus.test</groupId>
     <artifactId>org.jboss.tools.quarkus.runtime.test</artifactId>
     
     <packaging>eclipse-test-plugin</packaging>

--- a/test/org.jboss.tools.quarkus.ui.test/pom.xml
+++ b/test/org.jboss.tools.quarkus.ui.test/pom.xml
@@ -22,12 +22,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.quarkus.eclipse</groupId>
+        <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>test</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>io.quarkus.eclipse.test</groupId>
+    <groupId>org.jboss.tools.quarkus.test</groupId>
     <artifactId>org.jboss.tools.quarkus.ui.test</artifactId>
     
     <packaging>eclipse-test-plugin</packaging>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -27,6 +27,7 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
+    <groupId>org.jboss.tools.quarkus</groupId>
     <artifactId>test</artifactId>
 
     <packaging>pom</packaging>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>