### PR TITLE
JBIDE-26816: Update bundles ids of the Quarkus plugins/feature to org.jboss.tools.quarkus.* - Change the maven group id of the plugins to 'org.jboss.tools.quarkus.plugin'

### DIFF
--- a/plugin/org.jboss.tools.quarkus.cheatsheet/pom.xml
+++ b/plugin/org.jboss.tools.quarkus.cheatsheet/pom.xml
@@ -22,12 +22,12 @@
   <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.quarkus.eclipse</groupId>
+        <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>plugin</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>io.quarkus.eclipse.plugin</groupId>
+    <groupId>org.jboss.tools.quarkus.plugin</groupId>
     <artifactId>org.jboss.tools.quarkus.cheatsheet</artifactId>
   
     <packaging>eclipse-plugin</packaging>

--- a/plugin/org.jboss.tools.quarkus.core/pom.xml
+++ b/plugin/org.jboss.tools.quarkus.core/pom.xml
@@ -22,12 +22,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.quarkus.eclipse</groupId>
+        <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>plugin</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>io.quarkus.eclipse.plugin</groupId>
+    <groupId>org.jboss.tools.quarkus.plugin</groupId>
     <artifactId>org.jboss.tools.quarkus.core</artifactId>
     
     <packaging>eclipse-plugin</packaging>

--- a/plugin/org.jboss.tools.quarkus.runtime/pom.xml
+++ b/plugin/org.jboss.tools.quarkus.runtime/pom.xml
@@ -22,12 +22,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.quarkus.eclipse</groupId>
+        <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>plugin</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>io.quarkus.eclipse.plugin</groupId>
+    <groupId>org.jboss.tools.quarkus.plugin</groupId>
     <artifactId>org.jboss.tools.quarkus.runtime</artifactId>
  
     <packaging>eclipse-plugin</packaging>

--- a/plugin/org.jboss.tools.quarkus.ui/pom.xml
+++ b/plugin/org.jboss.tools.quarkus.ui/pom.xml
@@ -22,12 +22,12 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>io.quarkus.eclipse</groupId>
+        <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>plugin</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>io.quarkus.eclipse.plugin</groupId>
+    <groupId>org.jboss.tools.quarkus.plugin</groupId>
     <artifactId>org.jboss.tools.quarkus.ui</artifactId>
 
     <packaging>eclipse-plugin</packaging>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -25,6 +25,7 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
+    <groupId>org.jboss.tools.quarkus</groupId>
     <artifactId>plugin</artifactId>
     
     <packaging>pom</packaging>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>