### PR TITLE
JBIDE-26816: Update bundles ids of the Quarkus plugins/feature to org.jboss.tools.quarkus.* - Use 'org.jboss.tools.quarkus.tests' as the maven group id

### DIFF
--- a/tests/org.jboss.tools.quarkus.bot.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.bot.test/pom.xml
@@ -27,7 +27,7 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>org.jboss.tools.quarkus.test</groupId>
+    <groupId>org.jboss.tools.quarkus.tests</groupId>
     <artifactId>org.jboss.tools.quarkus.bot.test</artifactId>
     
     <packaging>eclipse-test-plugin</packaging>

--- a/tests/org.jboss.tools.quarkus.core.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.core.test/pom.xml
@@ -27,7 +27,7 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.jboss.tools.quarkus.test</groupId>
+    <groupId>org.jboss.tools.quarkus.tests</groupId>
     <artifactId>org.jboss.tools.quarkus.core.test</artifactId>
 
     <packaging>eclipse-test-plugin</packaging>

--- a/tests/org.jboss.tools.quarkus.runtime.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.runtime.test/pom.xml
@@ -27,7 +27,7 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>org.jboss.tools.quarkus.test</groupId>
+    <groupId>org.jboss.tools.quarkus.tests</groupId>
     <artifactId>org.jboss.tools.quarkus.runtime.test</artifactId>
     
     <packaging>eclipse-test-plugin</packaging>

--- a/tests/org.jboss.tools.quarkus.ui.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.ui.test/pom.xml
@@ -27,7 +27,7 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>org.jboss.tools.quarkus.test</groupId>
+    <groupId>org.jboss.tools.quarkus.tests</groupId>
     <artifactId>org.jboss.tools.quarkus.ui.test</artifactId>
     
     <packaging>eclipse-test-plugin</packaging>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>