### PR TITLE
JBIDE-26816: Update bundles ids of the Quarkus plugins/feature to org.jboss.tools.quarkus.* - Change the maven group id of the feature to 'org.jboss.tools.quarkus.feature'

### DIFF
--- a/feature/org.jboss.tools.quarkus.feature/pom.xml
+++ b/feature/org.jboss.tools.quarkus.feature/pom.xml
@@ -27,7 +27,7 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>io.quarkus.eclipse.feature</groupId>
+    <groupId>org.jboss.tools.quarkus.feature</groupId>
     <artifactId>org.jboss.tools.quarkus.feature</artifactId>
     
     <packaging>eclipse-feature</packaging>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -27,6 +27,7 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
+    <groupId>org.jboss.tools.quarkus</groupId>
     <artifactId>feature</artifactId>
     
     <packaging>pom</packaging>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>