### PR TITLE
JBIDE-26816: Update bundles ids of the Quarkus plugins/feature to org.jboss.tools.quarkus.* - Use 'org.jboss.tools.quarkus' as the parent group id in 'org.jboss.tools.quarkus.feature'

### DIFF
--- a/features/org.jboss.tools.quarkus.feature/pom.xml
+++ b/features/org.jboss.tools.quarkus.feature/pom.xml
@@ -22,8 +22,8 @@
     <modelVersion>4.0.0</modelVersion>
     
     <parent>
-        <groupId>io.quarkus.eclipse</groupId>
-        <artifactId>feature</artifactId>
+        <groupId>org.jboss.tools.quarkus</groupId>
+        <artifactId>features</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>