### PR TITLE
JBIDE-26816: Update bundles ids of the Quarkus plugins/feature to org.jboss.tools.quarkus.* - Remove unneeded group id tags

### DIFF
--- a/features/pom.xml
+++ b/features/pom.xml
@@ -27,7 +27,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>org.jboss.tools.quarkus</groupId>
     <artifactId>features</artifactId>
     
     <packaging>pom</packaging>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -25,7 +25,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>org.jboss.tools.quarkus</groupId>
     <artifactId>plugins</artifactId>
     
     <packaging>pom</packaging>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -27,7 +27,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>org.jboss.tools.quarkus</groupId>
     <artifactId>site</artifactId>
 
     <packaging>pom</packaging>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -27,7 +27,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     
-    <groupId>org.jboss.tools.quarkus</groupId>
     <artifactId>tests</artifactId>
 
     <packaging>pom</packaging>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>