### PR TITLE
JBIDE-26826: Change the package names from 'io.quarkus.eclipse.*' into 'org.jboss.tools.quarkus.*' - Changes for 'org.jboss.tools.quarkus.ui.test'

### DIFF
--- a/tests/org.jboss.tools.quarkus.ui.test/src/org/jboss/tools/quarkus/ui/action/CreateProjectActionTest.java
+++ b/tests/org.jboss.tools.quarkus.ui.test/src/org/jboss/tools/quarkus/ui/action/CreateProjectActionTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.ui.action;
+package org.jboss.tools.quarkus.ui.action;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,6 +25,8 @@ import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.eclipse.ui.action.CreateProjectAction;
 
 public class CreateProjectActionTest {
 

--- a/tests/org.jboss.tools.quarkus.ui.test/src/org/jboss/tools/quarkus/ui/view/ExtensionsViewTest.java
+++ b/tests/org.jboss.tools.quarkus.ui.test/src/org/jboss/tools/quarkus/ui/view/ExtensionsViewTest.java
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.ui.view;
+package org.jboss.tools.quarkus.ui.view;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
+
+import io.quarkus.eclipse.ui.view.ExtensionsView;
 
 public class ExtensionsViewTest {
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>