### PR TITLE
JBIDE-26826: Change the package names from 'io.quarkus.eclipse.*' into 'org.jboss.tools.quarkus.*' - Changes for 'org.jboss.tools.quarkus.cheatsheet'

### DIFF
--- a/plugins/org.jboss.tools.quarkus.cheatsheet/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.cheatsheet/META-INF/MANIFEST.MF
@@ -13,4 +13,4 @@ Require-Bundle: org.jboss.tools.quarkus.ui,
  org.eclipse.ui,
  org.eclipse.ui.cheatsheets
 Bundle-ActivationPolicy: lazy
-Bundle-Activator: io.quarkus.eclipse.cheatsheet.Activator
+Bundle-Activator: org.jboss.tools.quarkus.cheatsheet.Activator

--- a/plugins/org.jboss.tools.quarkus.cheatsheet/content/getting-started-guide.xml
+++ b/plugins/org.jboss.tools.quarkus.cheatsheet/content/getting-started-guide.xml
@@ -33,8 +33,8 @@ This guide covers:<br/>
    <item 
          title="Switch to the Quarkus perspective">
       <action 
-              pluginId="io.quarkus.eclipse.cheatsheet"
-              class="io.quarkus.eclipse.cheatsheet.ShowQuarkusPerspectiveAction"/>
+              pluginId="org.jboss.tools.quarkus.cheatsheet"
+              class="org.jboss.tools.quarkus.cheatsheet.ShowQuarkusPerspectiveAction"/>
       <description>
 A lot of the Quarkus functionality is more easily accessible when you are working in the Quarkus perspective. 
 You can change to the Quarkus perspective by bringing up the list of perspectives pushing the perspectives <img href='perspectives.png'/> icon
@@ -46,8 +46,8 @@ entry.
    <item
          title="Bootstrapping the Project">
       <action
-            pluginId="io.quarkus.eclipse.cheatsheet"
-            class="io.quarkus.eclipse.cheatsheet.OpenCreateProjectWizardAction"/>      
+            pluginId="org.jboss.tools.quarkus.cheatsheet"
+            class="org.jboss.tools.quarkus.cheatsheet.OpenCreateProjectWizardAction"/>      
       <description>
 The most general way to create a Quarkus project in Eclipse is to open up the 'New' wizard by selecting 'File->New->Other...' 
 or by pressing 'Ctrl+N' (or 'Cmd+N' on OS X) and subsequently selecting 'Quarkus->Quarkus Project'.<br/>

--- a/plugins/org.jboss.tools.quarkus.cheatsheet/plugin.xml
+++ b/plugins/org.jboss.tools.quarkus.cheatsheet/plugin.xml
@@ -20,11 +20,11 @@
    <extension
          point="org.eclipse.ui.cheatsheets.cheatSheetContent">
       <category
-            id="io.quarkus.eclipse.cheatsheet"
+            id="org.jboss.tools.quarkus.cheatsheet"
             name="Quarkus">
       </category>
       <cheatsheet
-            category="io.quarkus.eclipse.cheatsheet"
+            category="org.jboss.tools.quarkus.cheatsheet"
             composite="false"
             contentFile="content/getting-started-guide.xml"
             id="org.eclipse.ui.cheatsheet.gettingStartedGuide"

--- a/plugins/org.jboss.tools.quarkus.cheatsheet/src/org/jboss/tools/quarkus/cheatsheet/Activator.java
+++ b/plugins/org.jboss.tools.quarkus.cheatsheet/src/org/jboss/tools/quarkus/cheatsheet/Activator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.cheatsheet;
+package org.jboss.tools.quarkus.cheatsheet;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -22,7 +22,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 
 public class Activator extends AbstractUIPlugin {
 	
-	public final static String ID = "io.quarkus.eclipse.cheatsheet";
+	public final static String ID = "org.jboss.tools.quarkus.cheatsheet";
 	public final static Activator DEFAULT = new Activator();
 
 	public void logError(Throwable t) {

--- a/plugins/org.jboss.tools.quarkus.cheatsheet/src/org/jboss/tools/quarkus/cheatsheet/OpenCreateProjectWizardAction.java
+++ b/plugins/org.jboss.tools.quarkus.cheatsheet/src/org/jboss/tools/quarkus/cheatsheet/OpenCreateProjectWizardAction.java
@@ -14,26 +14,34 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.cheatsheet;
+package org.jboss.tools.quarkus.cheatsheet;
 
 import org.eclipse.jface.action.Action;
+import org.eclipse.jface.window.Window;
+import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.cheatsheets.ICheatSheetAction;
 import org.eclipse.ui.cheatsheets.ICheatSheetManager;
 
-public class ShowQuarkusPerspectiveAction extends Action implements ICheatSheetAction {
+import io.quarkus.eclipse.ui.wizard.CreateProjectWizard;
+
+public class OpenCreateProjectWizardAction extends Action implements ICheatSheetAction {
 
 	@Override
 	public void run(String[] params, ICheatSheetManager manager) {
-		try {
-			IWorkbench workbench = PlatformUI.getWorkbench();
-			IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
-			workbench.showPerspective("io.quarkus.eclipse.ui.perspective", window);
-		} catch (WorkbenchException e) {
-			Activator.DEFAULT.logError(e);
+		IWorkbench workbench = PlatformUI.getWorkbench();
+		IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
+		CreateProjectWizard createProjectWizard = new CreateProjectWizard();
+		createProjectWizard.init(workbench, null);
+		WizardDialog dialog = new WizardDialog(window.getShell(), createProjectWizard);
+		dialog.create();
+		int result = dialog.open();
+		if (result == Window.CANCEL) {
+			notifyResult(false);
+		} else if (result == Window.OK) {
+			notifyResult(true);
 		}
 	}
 

--- a/plugins/org.jboss.tools.quarkus.cheatsheet/src/org/jboss/tools/quarkus/cheatsheet/ShowQuarkusPerspectiveAction.java
+++ b/plugins/org.jboss.tools.quarkus.cheatsheet/src/org/jboss/tools/quarkus/cheatsheet/ShowQuarkusPerspectiveAction.java
@@ -14,34 +14,26 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.cheatsheet;
+package org.jboss.tools.quarkus.cheatsheet;
 
 import org.eclipse.jface.action.Action;
-import org.eclipse.jface.window.Window;
-import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.WorkbenchException;
 import org.eclipse.ui.cheatsheets.ICheatSheetAction;
 import org.eclipse.ui.cheatsheets.ICheatSheetManager;
 
-import io.quarkus.eclipse.ui.wizard.CreateProjectWizard;
-
-public class OpenCreateProjectWizardAction extends Action implements ICheatSheetAction {
+public class ShowQuarkusPerspectiveAction extends Action implements ICheatSheetAction {
 
 	@Override
 	public void run(String[] params, ICheatSheetManager manager) {
-		IWorkbench workbench = PlatformUI.getWorkbench();
-		IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
-		CreateProjectWizard createProjectWizard = new CreateProjectWizard();
-		createProjectWizard.init(workbench, null);
-		WizardDialog dialog = new WizardDialog(window.getShell(), createProjectWizard);
-		dialog.create();
-		int result = dialog.open();
-		if (result == Window.CANCEL) {
-			notifyResult(false);
-		} else if (result == Window.OK) {
-			notifyResult(true);
+		try {
+			IWorkbench workbench = PlatformUI.getWorkbench();
+			IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
+			workbench.showPerspective("io.quarkus.eclipse.ui.perspective", window);
+		} catch (WorkbenchException e) {
+			Activator.DEFAULT.logError(e);
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>