### PR TITLE
JBIDE-26826: Change the package names from 'io.quarkus.eclipse.*' into 'org.jboss.tools.quarkus.*' - Changes for 'org.jboss.tools.quarkus.ui'

### DIFF
--- a/plugins/org.jboss.tools.quarkus.cheatsheet/src/org/jboss/tools/quarkus/cheatsheet/OpenCreateProjectWizardAction.java
+++ b/plugins/org.jboss.tools.quarkus.cheatsheet/src/org/jboss/tools/quarkus/cheatsheet/OpenCreateProjectWizardAction.java
@@ -24,8 +24,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.cheatsheets.ICheatSheetAction;
 import org.eclipse.ui.cheatsheets.ICheatSheetManager;
-
-import io.quarkus.eclipse.ui.wizard.CreateProjectWizard;
+import org.jboss.tools.quarkus.ui.wizard.CreateProjectWizard;
 
 public class OpenCreateProjectWizardAction extends Action implements ICheatSheetAction {
 

--- a/plugins/org.jboss.tools.quarkus.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.jboss.tools.quarkus.core,
  org.eclipse.ui,
  org.eclipse.ui.workbench,
  org.eclipse.jdt.launching
-Export-Package: io.quarkus.eclipse.ui.action,
- io.quarkus.eclipse.ui.perspective,
- io.quarkus.eclipse.ui.view,
- io.quarkus.eclipse.ui.wizard
+Export-Package: org.jboss.tools.quarkus.ui.action,
+ org.jboss.tools.quarkus.ui.perspective,
+ org.jboss.tools.quarkus.ui.view,
+ org.jboss.tools.quarkus.ui.wizard

--- a/plugins/org.jboss.tools.quarkus.ui/plugin.xml
+++ b/plugins/org.jboss.tools.quarkus.ui/plugin.xml
@@ -20,28 +20,28 @@
    <extension
          point="org.eclipse.ui.newWizards">
       <category
-            id="io.quarkus.eclipse.ui.wizards"
+            id="org.jboss.tools.quarkus.ui.wizards"
             name="Quarkus">
       </category>
       <wizard
-            category="io.quarkus.eclipse.ui.wizards"
-            class="io.quarkus.eclipse.ui.wizard.CreateProjectWizard"
+            category="org.jboss.tools.quarkus.ui.wizards"
+            class="org.jboss.tools.quarkus.ui.wizard.CreateProjectWizard"
             icon="icon/quarkus-16.png"
-            id="io.quarkus.eclipse.ui.wizard.createProject"
+            id="org.jboss.tools.quarkus.ui.wizard.createProject"
             name="Quarkus Project">
       </wizard>
    </extension>
    <extension
          point="org.eclipse.ui.views">
       <category
-            id="io.quarkus.eclipse.ui.views"
+            id="org.jboss.tools.quarkus.ui.views"
             name="Quarkus">
       </category>
       <view
-            category="io.quarkus.eclipse.ui.views"
-            class="io.quarkus.eclipse.ui.view.ExtensionsView"
+            category="org.jboss.tools.quarkus.ui.views"
+            class="org.jboss.tools.quarkus.ui.view.ExtensionsView"
             icon="icon/quarkus-16.png"
-            id="io.quarkus.eclipse.ui.view.extensionsView"
+            id="org.jboss.tools.quarkus.ui.view.extensionsView"
             name="Quarkus Extensions"
             restorable="true">
       </view>
@@ -49,35 +49,35 @@
    <extension
          point="org.eclipse.ui.perspectives">
       <perspective
-            class="io.quarkus.eclipse.ui.perspective.PerspectiveFactory"
+            class="org.jboss.tools.quarkus.ui.perspective.PerspectiveFactory"
             icon="icon/quarkus-16.png"
-            id="io.quarkus.eclipse.ui.perspective"
+            id="org.jboss.tools.quarkus.ui.perspective"
             name="Quarkus">
       </perspective>
    </extension>
    <extension
          point="org.eclipse.ui.perspectiveExtensions">
       <perspectiveExtension
-            targetID="io.quarkus.eclipse.ui.perspective">
+            targetID="org.jboss.tools.quarkus.ui.perspective">
          <newWizardShortcut
-               id="io.quarkus.eclipse.ui.wizard.createProject">
+               id="org.jboss.tools.quarkus.ui.wizard.createProject">
          </newWizardShortcut>
       </perspectiveExtension>
    </extension>
    <extension
          point="org.eclipse.debug.ui.launchConfigurationTabGroups">
       <launchConfigurationTabGroup
-            class="io.quarkus.eclipse.ui.launch.QuarkusLaunchConfigurationTabGroup"
-            id="io.quarkus.eclipse.ui.launchConfigurationTabGroup"
-            type="io.quarkus.eclipse.core.launchConfigurationType">
+            class="org.jboss.tools.quarkus.ui.launch.QuarkusLaunchConfigurationTabGroup"
+            id="org.jboss.tools.quarkus.launchConfigurationTabGroup"
+            type="org.jboss.tools.quarkus.core.launchConfigurationType">
       </launchConfigurationTabGroup>
    </extension>
    <extension
          point="org.eclipse.debug.ui.launchConfigurationTypeImages">
       <launchConfigurationTypeImage
-            configTypeID="io.quarkus.eclipse.core.launchConfigurationType"
+            configTypeID="org.jboss.tools.quarkus.core.launchConfigurationType"
             icon="icon/quarkus-16.png"
-            id="io.quarkus.eclipse.ui.launchConfigurationTypeImage">
+            id="org.jboss.tools.quarkus.ui.launchConfigurationTypeImage">
       </launchConfigurationTypeImage>
    </extension>
 </plugin>

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/action/CreateProjectAction.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/action/CreateProjectAction.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.ui.action;
+package org.jboss.tools.quarkus.ui.action;
 
 import java.util.HashMap;
 

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/launch/QuarkusLaunchConfigurationTabGroup.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/launch/QuarkusLaunchConfigurationTabGroup.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.ui.launch;
+package org.jboss.tools.quarkus.ui.launch;
 
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/perspective/PerspectiveFactory.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/perspective/PerspectiveFactory.java
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.ui.perspective;
+package org.jboss.tools.quarkus.ui.perspective;
 
 import org.eclipse.ui.IFolderLayout;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IPerspectiveFactory;
-
-import io.quarkus.eclipse.ui.view.ExtensionsView;
+import org.jboss.tools.quarkus.ui.view.ExtensionsView;
 
 public class PerspectiveFactory implements IPerspectiveFactory {
 

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/view/ExtensionsView.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/view/ExtensionsView.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.ui.view;
+package org.jboss.tools.quarkus.ui.view;
 
 import java.util.List;
 import java.util.Set;
@@ -42,7 +42,7 @@ import io.quarkus.maven.utilities.MojoUtils;
 
 public class ExtensionsView extends ViewPart {
 	
-	public static final String ID = "io.quarkus.eclipse.ui.view.extensionsView";
+	public static final String ID = "org.jboss.tools.quarkus.ui.view.extensionsView";
 
 	private Table table = null;
 	private Object currentProject = null;

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/wizard/CreateProjectWizard.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/wizard/CreateProjectWizard.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.ui.wizard;
+package org.jboss.tools.quarkus.ui.wizard;
 
 import java.net.URL;
 import java.util.HashMap;
@@ -27,10 +27,9 @@ import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
+import org.jboss.tools.quarkus.ui.action.CreateProjectAction;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
-
-import io.quarkus.eclipse.ui.action.CreateProjectAction;
 
 public class CreateProjectWizard extends Wizard implements INewWizard {
 	

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/wizard/CreateProjectWizardPage.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/wizard/CreateProjectWizardPage.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.ui.wizard;
+package org.jboss.tools.quarkus.ui.wizard;
 
 import java.io.File;
 

--- a/tests/org.jboss.tools.quarkus.ui.test/src/org/jboss/tools/quarkus/ui/action/CreateProjectActionTest.java
+++ b/tests/org.jboss.tools.quarkus.ui.test/src/org/jboss/tools/quarkus/ui/action/CreateProjectActionTest.java
@@ -24,9 +24,8 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+import org.jboss.tools.quarkus.ui.action.CreateProjectAction;
 import org.junit.jupiter.api.Test;
-
-import io.quarkus.eclipse.ui.action.CreateProjectAction;
 
 public class CreateProjectActionTest {
 

--- a/tests/org.jboss.tools.quarkus.ui.test/src/org/jboss/tools/quarkus/ui/view/ExtensionsViewTest.java
+++ b/tests/org.jboss.tools.quarkus.ui.test/src/org/jboss/tools/quarkus/ui/view/ExtensionsViewTest.java
@@ -18,9 +18,8 @@ package org.jboss.tools.quarkus.ui.view;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.jboss.tools.quarkus.ui.view.ExtensionsView;
 import org.junit.jupiter.api.Test;
-
-import io.quarkus.eclipse.ui.view.ExtensionsView;
 
 public class ExtensionsViewTest {
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>