### PR TITLE
JBIDE-26826: Change the package names from 'io.quarkus.eclipse.*' into 'org.jboss.tools.quarkus.*' - Changes for 'org.jboss.tools.quarkus.core.test'

### DIFF
--- a/tests/org.jboss.tools.quarkus.core.test/src/org/jboss/tools/quarkus/core/launch/LaunchUtilsTest.java
+++ b/tests/org.jboss.tools.quarkus.core.test/src/org/jboss/tools/quarkus/core/launch/LaunchUtilsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.core.launch;
+package org.jboss.tools.quarkus.core.launch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -28,6 +28,7 @@ import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.dev.DevModeMain;
+import io.quarkus.eclipse.core.launch.LaunchUtils;
 
 public class LaunchUtilsTest {
 	

--- a/tests/org.jboss.tools.quarkus.core.test/src/org/jboss/tools/quarkus/core/project/ProjectUtilsTest.java
+++ b/tests/org.jboss.tools.quarkus.core.test/src/org/jboss/tools/quarkus/core/project/ProjectUtilsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.core.project;
+package org.jboss.tools.quarkus.core.project;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>