### PR TITLE
JBIDE-26826: Change the package names from 'io.quarkus.eclipse.*' into 'org.jboss.tools.quarkus.*' - Changes for 'org.jboss.tools.quarkus.core'

### DIFF
--- a/plugins/org.jboss.tools.quarkus.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.core/META-INF/MANIFEST.MF
@@ -13,5 +13,5 @@ Require-Bundle: org.jboss.tools.quarkus.runtime,
  org.eclipse.debug.core,
  org.eclipse.jdt.launching,
  org.eclipse.m2e.core
-Export-Package: io.quarkus.eclipse.core.launch,
- io.quarkus.eclipse.core.project
+Export-Package: org.jboss.tools.quarkus.core.launch,
+ org.jboss.tools.quarkus.core.project

--- a/plugins/org.jboss.tools.quarkus.core/plugin.xml
+++ b/plugins/org.jboss.tools.quarkus.core/plugin.xml
@@ -20,8 +20,8 @@
    <extension
          point="org.eclipse.debug.core.launchConfigurationTypes">
       <launchConfigurationType
-            delegate="io.quarkus.eclipse.core.launch.QuarkusLaunchConfigurationDelegate"
-            id="io.quarkus.eclipse.core.launchConfigurationType"
+            delegate="org.jboss.tools.quarkus.core.launch.QuarkusLaunchConfigurationDelegate"
+            id="org.jboss.tools.quarkus.core.launchConfigurationType"
             modes="run, debug"
             name="Quarkus Launch Configuration">
       </launchConfigurationType>

--- a/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/launch/LaunchUtils.java
+++ b/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/launch/LaunchUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.core.launch;
+package org.jboss.tools.quarkus.core.launch;
 
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;

--- a/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/launch/QuarkusLaunchConfigurationDelegate.java
+++ b/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/launch/QuarkusLaunchConfigurationDelegate.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.core.launch;
+package org.jboss.tools.quarkus.core.launch;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;

--- a/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/project/ProjectUtils.java
+++ b/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/project/ProjectUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.core.project;
+package org.jboss.tools.quarkus.core.project;
 
 import java.io.File;
 import java.io.IOException;

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/action/CreateProjectAction.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/action/CreateProjectAction.java
@@ -19,8 +19,7 @@ package org.jboss.tools.quarkus.ui.action;
 import java.util.HashMap;
 
 import org.eclipse.jface.action.Action;
-
-import io.quarkus.eclipse.core.project.ProjectUtils;
+import org.jboss.tools.quarkus.core.project.ProjectUtils;
 
 public class CreateProjectAction extends Action implements Runnable {
 

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/launch/QuarkusLaunchConfigurationTabGroup.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/launch/QuarkusLaunchConfigurationTabGroup.java
@@ -21,8 +21,7 @@ import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.CommonTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
-
-import io.quarkus.eclipse.core.launch.LaunchUtils;
+import org.jboss.tools.quarkus.core.launch.LaunchUtils;
 
 public class QuarkusLaunchConfigurationTabGroup extends AbstractLaunchConfigurationTabGroup {
 

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/view/ExtensionsView.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/view/ExtensionsView.java
@@ -35,9 +35,9 @@ import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.ViewPart;
+import org.jboss.tools.quarkus.core.project.ProjectUtils;
 
 import io.quarkus.dependencies.Extension;
-import io.quarkus.eclipse.core.project.ProjectUtils;
 import io.quarkus.maven.utilities.MojoUtils;
 
 public class ExtensionsView extends ViewPart {

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/wizard/CreateProjectWizardPage.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/wizard/CreateProjectWizardPage.java
@@ -32,8 +32,7 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
-
-import io.quarkus.eclipse.core.project.ProjectUtils;
+import org.jboss.tools.quarkus.core.project.ProjectUtils;
 
 public class CreateProjectWizardPage extends WizardPage {
 	

--- a/tests/org.jboss.tools.quarkus.core.test/src/org/jboss/tools/quarkus/core/launch/LaunchUtilsTest.java
+++ b/tests/org.jboss.tools.quarkus.core.test/src/org/jboss/tools/quarkus/core/launch/LaunchUtilsTest.java
@@ -25,10 +25,10 @@ import java.lang.reflect.Proxy;
 
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+import org.jboss.tools.quarkus.core.launch.LaunchUtils;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.dev.DevModeMain;
-import io.quarkus.eclipse.core.launch.LaunchUtils;
 
 public class LaunchUtilsTest {
 	

--- a/tests/org.jboss.tools.quarkus.core.test/src/org/jboss/tools/quarkus/core/project/ProjectUtilsTest.java
+++ b/tests/org.jboss.tools.quarkus.core.test/src/org/jboss/tools/quarkus/core/project/ProjectUtilsTest.java
@@ -25,10 +25,9 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.jboss.tools.quarkus.core.project.ProjectUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import io.quarkus.eclipse.core.project.ProjectUtils;
 
 public class ProjectUtilsTest {
 	


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>