### PR TITLE
JBIDE-26826: Change the package names from 'io.quarkus.eclipse.*' into 'org.jboss.tools.quarkus.*' - Changes for 'org.jboss.tools.quarkus.runtime.test'

### DIFF
--- a/tests/org.jboss.tools.quarkus.runtime.test/src/org/jboss/tools/quarkus/runtime/VersionTest.java
+++ b/tests/org.jboss.tools.quarkus.runtime.test/src/org/jboss/tools/quarkus/runtime/VersionTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.quarkus.eclipse.runtime;
+package org.jboss.tools.quarkus.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>