### PR TITLE
JBIDE-26826: Change the package names from 'io.quarkus.eclipse.*' into 'org.jboss.tools.quarkus.*' - Fix some remaining loose ends

### DIFF
--- a/documentation/building/build.md
+++ b/documentation/building/build.md
@@ -20,10 +20,10 @@ You will need to have Maven installed. You can build the project by issuing `mvn
 
 <img src="images/build.png" width="400"/>
 
-When the build finishes you will find an installable Eclipse repository in the `repository/io.quarkus.eclipse.repository/target` folder. 
+When the build finishes you will find an installable Eclipse repository in the `repository/org.jboss.tools.quarkus.site/target` folder. 
 
 <img src="images/repository.png" width="400"/>
 
-The name of the repository is `io.quarkus.eclipse.repository-x.y.z-SNAPSHOT.zip`.
+The name of the repository is `org.jboss.tools.quarkus.site-x.y.z-SNAPSHOT.zip`.
 
 Now you can proceed with the installation of your repository in your Eclipse workbench by following the [installation instructions](../installation/install.md).

--- a/plugins/org.jboss.tools.quarkus.cheatsheet/src/org/jboss/tools/quarkus/cheatsheet/ShowQuarkusPerspectiveAction.java
+++ b/plugins/org.jboss.tools.quarkus.cheatsheet/src/org/jboss/tools/quarkus/cheatsheet/ShowQuarkusPerspectiveAction.java
@@ -31,7 +31,7 @@ public class ShowQuarkusPerspectiveAction extends Action implements ICheatSheetA
 		try {
 			IWorkbench workbench = PlatformUI.getWorkbench();
 			IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
-			workbench.showPerspective("io.quarkus.eclipse.ui.perspective", window);
+			workbench.showPerspective("org.jboss.tools.quarkus.ui.perspective", window);
 		} catch (WorkbenchException e) {
 			Activator.DEFAULT.logError(e);
 		}

--- a/tests/org.jboss.tools.quarkus.bot.test/src/io/quarkus/eclipse/bot/test/SimpleTest.java
+++ b/tests/org.jboss.tools.quarkus.bot.test/src/io/quarkus/eclipse/bot/test/SimpleTest.java
@@ -1,4 +1,4 @@
-package io.quarkus.eclipse.bot.test;
+package org.jboss.tools.quarkus.bot.test;
 
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>