### PR TITLE
JBIDE-26827: Use 'org.jboss.tools.parent' as the parent pom of 'org.jboss.tools.quarkus'

### DIFF
--- a/plugins/org.jboss.tools.quarkus.runtime/pom.xml
+++ b/plugins/org.jboss.tools.quarkus.runtime/pom.xml
@@ -99,7 +99,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean.version}</version>
                 <configuration>
                     <filesets>
                         <fileset>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,12 @@
     
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.jboss.tools</groupId>
+	<parent>
+		<groupId>org.jboss.tools</groupId>
+		<artifactId>parent</artifactId>
+		<version>4.13.0.AM1-SNAPSHOT</version>
+	</parent>
+
     <artifactId>quarkus</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
@@ -30,10 +35,9 @@
     <properties>
         <jackson.version>2.9.8</jackson.version>
         <maven.version>3.6.0</maven.version>
-        <maven-clean.version>3.1.0</maven-clean.version>
         <plexus.version>3.1.1</plexus.version>
         <quarkus.version>0.20.0</quarkus.version>
-        <tycho-version>1.3.0</tycho-version>
+		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-quarkus.git</tycho.scmUrl>
     </properties>
     
     <modules>
@@ -48,19 +52,10 @@
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-maven-plugin</artifactId>
-                <version>${tycho-version}</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>
   
-    <repositories>
-        <repository>
-            <id>eclipse-2018-12</id>
-            <url>https://download.eclipse.org/releases/2018-12/</url>
-            <layout>p2</layout>
-        </repository>
-    </repositories>
-    
 </project>
 

--- a/tests/org.jboss.tools.quarkus.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.quarkus.core.test/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Bundle-Version: 0.0.1.qualifier
 Fragment-Host: org.jboss.tools.quarkus.core
 Automatic-Module-Name: org.jboss.tools.quarkus.core.test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.jdt.junit5.runtime,
+Import-Package: org.junit,
  org.junit.jupiter.api

--- a/tests/org.jboss.tools.quarkus.core.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.core.test/pom.xml
@@ -32,4 +32,20 @@
 
     <packaging>eclipse-test-plugin</packaging>
 
+    <build>
+         <plugins>
+			<plugin> 
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tychoVersion}</version>
+				<configuration>
+					<includes>
+						<include>**/*Test.class</include>
+					</includes>
+					<skip>${skipTests}</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/tests/org.jboss.tools.quarkus.runtime.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.runtime.test/pom.xml
@@ -32,4 +32,20 @@
     
     <packaging>eclipse-test-plugin</packaging>
     
+    <build>
+         <plugins>
+			<plugin> 
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tychoVersion}</version>
+				<configuration>
+					<includes>
+						<include>**/*Test.class</include>
+					</includes>
+					<skip>${skipTests}</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/tests/org.jboss.tools.quarkus.ui.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.ui.test/pom.xml
@@ -32,4 +32,20 @@
     
     <packaging>eclipse-test-plugin</packaging>
     
+    <build>
+         <plugins>
+			<plugin> 
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tychoVersion}</version>
+				<configuration>
+					<includes>
+						<include>**/*Test.class</include>
+					</includes>
+					<skip>${skipTests}</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
Signed-off-by: Koen Aers <koen.aers@gmail.com>