### PR TITLE
Use latest quarkus-ls 0.0.4 + remove content type mapping for Java files

### DIFF
--- a/plugins/org.jboss.tools.quarkus.lsp4e/plugin.xml
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/plugin.xml
@@ -36,10 +36,6 @@
             contentType="org.jboss.tools.quarkus.lsp4e"
             id="org.jboss.tools.quarkus.lsp4e">
       </contentTypeMapping>
-      <contentTypeMapping
-            contentType="org.eclipse.jdt.core.javaSource"
-            id="org.jboss.tools.quarkus.lsp4e">
-      </contentTypeMapping>
    </extension>
    
    <extension

--- a/plugins/org.jboss.tools.quarkus.lsp4e/pom.xml
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/pom.xml
@@ -33,7 +33,7 @@
     <packaging>eclipse-plugin</packaging>
 
     <properties>
-        <quarkus-ls.version>0.0.2-SNAPSHOT</quarkus-ls.version>
+        <quarkus-ls.version>0.0.4-SNAPSHOT</quarkus-ls.version>
         <enforcer.skip>true</enforcer.skip>
     </properties>
 


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>