### PR TITLE
JBIDE-27025: Use extension shortId when sending request to code.quark…

### DIFF
--- a/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/QuarkusCoreConstants.java
+++ b/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/QuarkusCoreConstants.java
@@ -32,6 +32,7 @@ public class QuarkusCoreConstants {
     public static final String CODE_PATH_PARAMETER_NAME = "p";
 
     public static final String CODE_EXTENSIONS_PARAMETER_NAME = "e";
+    public static final String CODE_EXTENSIONS_SHORT_PARAMETER_NAME = "s";
 
     public static final String CODE_CLIENT_NAME_PARAMETER_NAME = "cn";
 

--- a/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/code/model/QuarkusExtension.java
+++ b/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/code/model/QuarkusExtension.java
@@ -54,6 +54,9 @@ public class QuarkusExtension {
     
     @JsonProperty("default")
     private boolean defaultExtension;
+    
+    @JsonProperty("shortId")
+    private String shortId;
 
     public String getCategory() {
         return category;
@@ -165,6 +168,20 @@ public class QuarkusExtension {
 	 */
 	public void setDefaultExtension(boolean defaultExtension) {
 		this.defaultExtension = defaultExtension;
+	}
+
+	/**
+	 * @return the shortId
+	 */
+	public String getShortId() {
+		return shortId;
+	}
+
+	/**
+	 * @param shortId the shortId to set
+	 */
+	public void setShortId(String shortId) {
+		this.shortId = shortId;
 	}
 
 	public String asLabel() {

--- a/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/code/model/QuarkusModelRegistry.java
+++ b/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/code/model/QuarkusModelRegistry.java
@@ -19,7 +19,7 @@ import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_CLIENT_CONT
 import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_CLIENT_NAME_PARAMETER_NAME;
 import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_CLIENT_NAME_PARAMETER_VALUE;
 import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_ENDPOINT_URL;
-import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_EXTENSIONS_PARAMETER_NAME;
+import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_EXTENSIONS_SHORT_PARAMETER_NAME;
 import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_GROUP_ID_PARAMETER_NAME;
 import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_PATH_PARAMETER_NAME;
 import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_TOOL_PARAMETER_NAME;
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -109,7 +110,7 @@ public class QuarkusModelRegistry {
         builder.append(CODE_VERSION_PARAMETER_NAME).append('=').append(version).append('&');
         builder.append(CODE_CLASSNAME_PARAMETER_NAME).append('=').append(className).append('&');
         builder.append(CODE_PATH_PARAMETER_NAME).append('=').append(path).append('&');
-        selected.forEach(extension -> builder.append(CODE_EXTENSIONS_PARAMETER_NAME).append('=').append(extension.getId()).append('&'));
+        builder.append(CODE_EXTENSIONS_SHORT_PARAMETER_NAME).append('=').append(selected.stream().map(e -> e.getShortId()).collect(Collectors.joining("."))).append('&');
         builder.append(CODE_CLIENT_NAME_PARAMETER_NAME).append('=').append(CODE_CLIENT_NAME_PARAMETER_VALUE).append('&');
         builder.append(CODE_CLIENT_CONTACT_EMAIL_PARAMETER_NAME).append('=').append(CODE_CLIENT_CONTACT_EMAIL_PARAMETER_VALUE);
         try {

--- a/tests/org.jboss.tools.quarkus.core.test/resources/single-extension.json
+++ b/tests/org.jboss.tools.quarkus.core.test/resources/single-extension.json
@@ -1,0 +1,1 @@
+[{"category":"Web","default":true,"description":"REST framework implementing JAX-RS and more","guide":"https://quarkus.io/guides/rest-json","id":"io.quarkus:quarkus-resteasy","keywords":["resteasy","jaxrs","web","rest"],"labels":["resteasy","jaxrs","web","rest"],"name":"RESTEasy JAX-RS","order":0,"shortName":"jax-rs","shortId":"98e"}]

--- a/tests/org.jboss.tools.quarkus.core.test/src/org/jboss/tools/quarkus/core/code/model/QuarkusExtensionsTest.java
+++ b/tests/org.jboss.tools.quarkus.core.test/src/org/jboss/tools/quarkus/core/code/model/QuarkusExtensionsTest.java
@@ -35,6 +35,15 @@ public class QuarkusExtensionsTest {
     }
 
     @Test
+    public void checkExtensionWithShortId() throws IOException {
+        QuarkusModel model = new QuarkusModel(load("/single-extension.json"));
+        assertEquals(1, model.getCategories().size());
+        assertEquals(1, model.getCategories().get(0).getExtensions().size());
+        assertEquals(RESTEASY_JAX_RS_EXTENSION_NAME, model.getCategories().get(0).getExtensions().get(0).getName());
+        assertEquals("98e", model.getCategories().get(0).getExtensions().get(0).getShortId());
+    }
+
+    @Test
     public void checkStableExtensionWithStatus() throws IOException {
         QuarkusModel model = new QuarkusModel(load("/single-stable-extension-with-status.json"));
         assertEquals(1, model.getCategories().size());


### PR DESCRIPTION
…us.io

To test run the Quarkus wizard with as much extensions selected

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
