### PR TITLE
JBIDE-27182: Reworked "create new quarkus project" cause of

### DIFF
--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/launch/configuration/AbstractLaunchConfigurationTest.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/launch/configuration/AbstractLaunchConfigurationTest.java
@@ -10,8 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.integration.tests.launch.configuration;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -26,12 +24,9 @@ import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.eclipse.reddeer.swt.impl.button.PushButton;
 import org.eclipse.reddeer.swt.impl.menu.ContextMenuItem;
 import org.eclipse.reddeer.swt.impl.table.DefaultTableItem;
-import org.eclipse.reddeer.swt.impl.text.LabeledText;
 import org.eclipse.reddeer.swt.impl.tree.DefaultTreeItem;
-import org.eclipse.reddeer.workbench.impl.shell.WorkbenchShell;
-import org.jboss.tools.quarkus.reddeer.wizard.CodeProjectTypeWizardPage;
-import org.jboss.tools.quarkus.reddeer.wizard.QuarkusWizard;
 import org.junit.After;
+import org.jboss.tools.quarkus.integration.tests.project.AbstractCreateNewProjectTest;
 import org.jboss.tools.quarkus.reddeer.common.QuarkusLabels.TextLabels;
 import org.jboss.tools.quarkus.reddeer.ui.launch.QuarkusLaunchConfigurationTabGroup;
 import org.eclipse.reddeer.swt.impl.toolbar.DefaultToolItem;
@@ -44,27 +39,10 @@ import org.eclipse.reddeer.swt.impl.toolbar.DefaultToolItem;
 
 public abstract class AbstractLaunchConfigurationTest {
 	public static void createNewQuarkusProject(String projectName, String projectType) {
-		new WorkbenchShell().setFocus();
+		AbstractCreateNewProjectTest.testCreateNewProject(projectName, projectType);
+		AbstractCreateNewProjectTest.checkJdkVersion(projectName, projectType);
 
-		QuarkusWizard qw = new QuarkusWizard();
-		qw.open();
-		assertTrue(qw.isOpen());
-
-		CodeProjectTypeWizardPage wp = new CodeProjectTypeWizardPage(qw);
-		wp.setProjectName(projectName);
-		if (projectType.equals(TextLabels.MAVEN_TYPE)) {
-			wp.setMavenProjectType();
-		} else if (projectType.equals(TextLabels.GRADLE_TYPE)) {
-			wp.setGradleProjectType();
-		}
-
-		qw.next();
-		if (projectType.equals(TextLabels.GRADLE_TYPE)) {
-			new LabeledText(TextLabels.ARTIFACT_ID).setText(projectName);
-		}
-		qw.finish(TimePeriod.VERY_LONG);
-
-		assertTrue(new ProjectExplorer().containsProject(projectName));
+		AbstractCreateNewProjectTest.checkProblemsView();
 	}
 
 	public void testNewQuarkusConfiguration(String projectName, ConsoleView consoleView) {
@@ -123,13 +101,13 @@ public abstract class AbstractLaunchConfigurationTest {
 		}
 		new DefaultToolItem("Terminate").click();
 	}
-	
+
 	public void deleteNewQuarkusConfiguration(String projectName) {
 		new QuarkusLaunchConfigurationTabGroup().selectProject(projectName);
 		new QuarkusLaunchConfigurationTabGroup().openRunConfiguration();
-		
+
 		new DefaultTreeItem(TextLabels.QUARKUS_APPLICATION_TREE_ITEM, projectName + TextLabels.CONFIGURATION).select();
-		
+
 		new DefaultToolItem("Delete selected launch configuration(s)").click();
 		new PushButton("Delete").click();
 		new PushButton("Close").click();

--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/launch/configuration/CreateNewQuarkusConfigurationGradleTest.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/launch/configuration/CreateNewQuarkusConfigurationGradleTest.java
@@ -29,8 +29,7 @@ import org.junit.runner.RunWith;
 @RunWith(RedDeerSuite.class)
 public class CreateNewQuarkusConfigurationGradleTest extends AbstractLaunchConfigurationTest {
 
-	private static String GRADLE_PROJECT_NAME = "code-with-quarkus"; // w8ing for fix
-																		// https://issues.redhat.com/browse/JBIDE-27073
+	private static String GRADLE_PROJECT_NAME = "testgrdlconf";
 	private static ConsoleView consoleView;
 
 	@BeforeClass

--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/launch/configuration/CreateNewQuarkusConfigurationMavenTest.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/launch/configuration/CreateNewQuarkusConfigurationMavenTest.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 @RunWith(RedDeerSuite.class)
 public class CreateNewQuarkusConfigurationMavenTest extends AbstractLaunchConfigurationTest {
 
-	private static String MAVEN_PROJECT_NAME = "testProjectMaven";
+	private static String MAVEN_PROJECT_NAME = "testmvnconf";
 	private static ConsoleView consoleView;
 
 	@BeforeClass
@@ -41,5 +41,6 @@ public class CreateNewQuarkusConfigurationMavenTest extends AbstractLaunchConfig
 	@Test
 	public void testNewQuarkusMavenConfiguration() {
 		testNewQuarkusConfiguration(MAVEN_PROJECT_NAME, consoleView);
+
 	}
 }

--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/AbstractCreateNewProjectTest.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/AbstractCreateNewProjectTest.java
@@ -1,0 +1,153 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.quarkus.integration.tests.project;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.reddeer.common.wait.TimePeriod;
+import org.eclipse.reddeer.common.wait.WaitWhile;
+import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
+import org.eclipse.reddeer.eclipse.ui.problems.Problem;
+import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView;
+import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView.ProblemType;
+import org.eclipse.reddeer.swt.impl.button.PushButton;
+import org.eclipse.reddeer.swt.impl.menu.ContextMenuItem;
+import org.eclipse.reddeer.swt.impl.text.LabeledText;
+import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
+import org.eclipse.reddeer.workbench.impl.editor.TextEditor;
+import org.eclipse.reddeer.workbench.impl.shell.WorkbenchShell;
+import org.jboss.tools.quarkus.reddeer.common.QuarkusLabels.TextLabels;
+import org.jboss.tools.quarkus.reddeer.wizard.CodeProjectTypeWizardPage;
+import org.jboss.tools.quarkus.reddeer.wizard.QuarkusWizard;
+import org.junit.After;
+
+/**
+ * 
+ * @author olkornii@redhat.com
+ *
+ */
+public abstract class AbstractCreateNewProjectTest {
+
+	private static String jdkVersion11 = "11";
+	private static String propertyName = "java.specification.version";
+	
+	private static String pomFile = "pom.xml";
+	private static String gradleBuildFile = "build.gradle";
+
+	private static String mavenCompilerSourceStart = "<maven.compiler.source>";
+	private static String mavenCompilerSourceEnd = "</maven.compiler.source>";
+	private static String mavenCompilerTargetStart = "<maven.compiler.target>";
+	private static String mavenCompilerTargetEnd = "</maven.compiler.target>";
+
+	private static String gradleCompilerSource = "sourceCompatibility = JavaVersion.VERSION_";
+	private static String gradleCompilerTarget = "targetCompatibility = JavaVersion.VERSION_";
+
+	public static void testCreateNewProject(String projectName, String projectType) {
+		new WorkbenchShell().setFocus();
+
+		QuarkusWizard qw = new QuarkusWizard();
+		qw.open();
+		assertTrue(qw.isOpen());
+
+		CodeProjectTypeWizardPage wp = new CodeProjectTypeWizardPage(qw);
+		wp.setProjectName(projectName);
+		if (projectType.equals(TextLabels.MAVEN_TYPE)) {
+			wp.setMavenProjectType();
+		} else if (projectType.equals(TextLabels.GRADLE_TYPE)) {
+			wp.setGradleProjectType();
+		}
+
+		qw.next();
+		if (projectType.equals(TextLabels.GRADLE_TYPE)) {
+			new LabeledText(TextLabels.ARTIFACT_ID).setText(projectName);
+		}
+		qw.finish(TimePeriod.VERY_LONG);
+
+		assertTrue(new ProjectExplorer().containsProject(projectName));
+	}
+
+	public static void checkJdkVersion(String projectName, String projectType) {
+		String javaVersion = System.getProperty(propertyName);
+		boolean isFound = javaVersion.contains(jdkVersion11);
+
+		String newSource;
+		String newTarget;
+		String actualSource;
+		String actualTarget;
+		String openFile;
+		
+		if (!isFound) {
+			if (projectType.equals(TextLabels.GRADLE_TYPE)) {
+				javaVersion = javaVersion.replaceAll("\\.", "_");
+				newSource = gradleCompilerSource + javaVersion;
+				newTarget = gradleCompilerTarget + javaVersion;
+				actualSource = gradleCompilerSource + jdkVersion11;
+				actualTarget = gradleCompilerTarget + jdkVersion11;
+				openFile = gradleBuildFile;
+			} else {
+				newSource = mavenCompilerSourceStart + javaVersion + mavenCompilerSourceEnd;
+				newTarget = mavenCompilerTargetStart + javaVersion + mavenCompilerTargetEnd;
+				actualSource = mavenCompilerSourceStart + jdkVersion11 + mavenCompilerSourceEnd;
+				actualTarget = mavenCompilerTargetStart + jdkVersion11 + mavenCompilerTargetEnd;
+				openFile = pomFile;
+			}
+			changeVersion(projectName, projectType, openFile, actualSource, actualTarget, newSource, newTarget);
+		}
+	}
+
+	private static void changeVersion(String projectName, String projectType, String openFile, String actualSource,
+			String actualTarget, String newSource, String newTarget) {
+		new ProjectExplorer().getProject(projectName).getProjectItem(openFile).select();
+		new ContextMenuItem(TextLabels.OPEN_WITH, TextLabels.TEXT_EDITOR).select();
+
+		TextEditor ed = new TextEditor(openFile);
+
+		changeLine(ed, actualSource, newSource);
+		changeLine(ed, actualTarget, newTarget);
+
+		ed.save();
+		new ProjectExplorer().selectProjects(projectName);
+
+		if (projectType.equals(TextLabels.GRADLE_TYPE)) {
+			new ContextMenuItem(TextLabels.GRADLE_CONTEXT_MENU_ITEM, TextLabels.REFRESH_GRADLE_PROJECT).select();
+		} else {
+			new ContextMenuItem(TextLabels.MAVEN_CONTEXT_MENU_ITEM, TextLabels.UPDATE_MAVEN_PROJECT).select();
+			new PushButton("OK").click();
+		}
+
+		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
+	}
+
+	private static void changeLine(TextEditor ed, String myActual, String myNew) {
+		ed.selectText(myActual);
+		int textPos = ed.getPositionOfText(myActual);
+		new ContextMenuItem(TextLabels.CUT_CONTEXT_MENU_ITEM).select();
+		ed.insertText(textPos, myNew);
+	}
+
+	public static void checkProblemsView() {
+		ProblemsView problemsView = new ProblemsView();
+		problemsView.open();
+		List<Problem> problems = problemsView.getProblems(ProblemType.ERROR);
+		assertEquals("There should be no errors in imported project", 0, problems.size());
+
+	}
+
+	@After
+	public void deleteProject() {
+		ProjectExplorer pe = new ProjectExplorer();
+		pe.open();
+		pe.deleteAllProjects(true);
+	}
+}

--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/CreateNewProjectTest.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/CreateNewProjectTest.java
@@ -10,24 +10,10 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.integration.tests.project;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import java.util.List;
-
-import org.eclipse.reddeer.common.wait.TimePeriod;
-import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
-import org.eclipse.reddeer.eclipse.ui.problems.Problem;
-import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView;
-import org.eclipse.reddeer.eclipse.ui.views.markers.ProblemsView.ProblemType;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
-import org.eclipse.reddeer.swt.impl.text.LabeledText;
-import org.eclipse.reddeer.workbench.impl.shell.WorkbenchShell;
 import org.jboss.tools.quarkus.reddeer.common.QuarkusLabels.TextLabels;
 import org.jboss.tools.quarkus.reddeer.perspective.QuarkusPerspective;
-import org.jboss.tools.quarkus.reddeer.wizard.CodeProjectTypeWizardPage;
-import org.jboss.tools.quarkus.reddeer.wizard.QuarkusWizard;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -38,65 +24,27 @@ import org.junit.runner.RunWith;
  */
 @OpenPerspective(QuarkusPerspective.class)
 @RunWith(RedDeerSuite.class)
-public class CreateNewProjectTest {
+public class CreateNewProjectTest extends AbstractCreateNewProjectTest {
 
-	private static String MAVEN_PROJECT_NAME = "testProjectMaven";
-	private static String GRADLE_PROJECT_NAME = "code-with-quarkus"; // w8 for JBIDE-27073
-																		// https://issues.redhat.com/browse/JBIDE-27073
+	private static String MAVEN_PROJECT_NAME = "testmvn";
+	private static String GRADLE_PROJECT_NAME = "testgrdl";
 
 	@Test
 	public void testNewNewQuarkusMavenProject() {
-		new WorkbenchShell().setFocus();
+		testCreateNewProject(MAVEN_PROJECT_NAME, TextLabels.MAVEN_TYPE);
+		checkJdkVersion(MAVEN_PROJECT_NAME, TextLabels.MAVEN_TYPE);
 
-		QuarkusWizard qw = new QuarkusWizard();
-		qw.open();
-		assertTrue(qw.isOpen());
-
-		CodeProjectTypeWizardPage wp = new CodeProjectTypeWizardPage(qw);
-		wp.setProjectName(MAVEN_PROJECT_NAME);
-		wp.setMavenProjectType();
-
-		qw.next();
-		qw.finish(TimePeriod.VERY_LONG);
-
-		assertTrue(new ProjectExplorer().containsProject(MAVEN_PROJECT_NAME));
 		checkProblemsView();
 	}
 
 	@Test
 	public void testNewNewQuarkusGradleProject() {
-		new WorkbenchShell().setFocus();
 
-		QuarkusWizard qw = new QuarkusWizard();
-		qw.open();
-		assertTrue(qw.isOpen());
+		testCreateNewProject(GRADLE_PROJECT_NAME, TextLabels.GRADLE_TYPE);
+		checkJdkVersion(GRADLE_PROJECT_NAME, TextLabels.GRADLE_TYPE);
 
-		CodeProjectTypeWizardPage wp = new CodeProjectTypeWizardPage(qw);
-		wp.setProjectName(GRADLE_PROJECT_NAME);
-		wp.setGradleProjectType();
-
-		qw.next();
-		new LabeledText(TextLabels.ARTIFACT_ID).setText(GRADLE_PROJECT_NAME);
-		qw.finish(TimePeriod.VERY_LONG);
-
-		assertTrue(new ProjectExplorer().containsProject(GRADLE_PROJECT_NAME));
 		checkProblemsView();
 
-	}
-
-	private void checkProblemsView() {
-		ProblemsView problemsView = new ProblemsView();
-		problemsView.open();
-		List<Problem> problems = problemsView.getProblems(ProblemType.ERROR);
-		assertEquals("There should be no errors in imported project", 0, problems.size());
-
-	}
-
-	@After
-	public void deleteProject() {
-		ProjectExplorer pe = new ProjectExplorer();
-		pe.open();
-		pe.deleteAllProjects(true);
 	}
 
 }

--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/InstallQuarkusExtensionTest.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/InstallQuarkusExtensionTest.java
@@ -31,10 +31,9 @@ import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequireme
 import org.eclipse.reddeer.swt.impl.menu.ContextMenuItem;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.eclipse.reddeer.workbench.impl.shell.WorkbenchShell;
+import org.jboss.tools.quarkus.reddeer.common.QuarkusLabels.TextLabels;
 import org.jboss.tools.quarkus.reddeer.perspective.QuarkusPerspective;
 import org.jboss.tools.quarkus.reddeer.view.ExtensionsView;
-import org.jboss.tools.quarkus.reddeer.wizard.CodeProjectTypeWizardPage;
-import org.jboss.tools.quarkus.reddeer.wizard.QuarkusWizard;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,21 +47,13 @@ import org.junit.runner.RunWith;
 public class InstallQuarkusExtensionTest {
 	
 	protected static final String WORKSPACE = ResourcesPlugin.getWorkspace().getRoot().getLocation().toString();
-
+	
 	@BeforeClass
 	public static void prepareWorkspace() {
-		QuarkusWizard qw = new QuarkusWizard();
-		qw.open();
-		assertTrue(qw.isOpen());
+		AbstractCreateNewProjectTest.testCreateNewProject("test", TextLabels.MAVEN_TYPE);
+		AbstractCreateNewProjectTest.checkJdkVersion("test", TextLabels.MAVEN_TYPE);
 
-		CodeProjectTypeWizardPage wp = new CodeProjectTypeWizardPage(qw);
-		wp.setProjectName("test");
-		wp.setMavenProjectType();
-
-		qw.next();
-		qw.finish(TimePeriod.VERY_LONG);
-
-		assertTrue(new ProjectExplorer().containsProject("test"));
+		AbstractCreateNewProjectTest.checkProblemsView();
 	}
 
 	@Test

--- a/test-framework/org.jboss.tools.quarkus.reddeer/src/org/jboss/tools/quarkus/reddeer/common/QuarkusLabels.java
+++ b/test-framework/org.jboss.tools.quarkus.reddeer/src/org/jboss/tools/quarkus/reddeer/common/QuarkusLabels.java
@@ -35,6 +35,10 @@ public class QuarkusLabels {
 		public static final String NEW_CONTEXT_ITEM = "New";
 		public static final String RUN_AS_CONTEXT_MENU_ITEM = "Run As";
 		public static final String RUN_CONFIGURATION_CONTEXT_MENU_ITEM = "Run Configurations...";
+		public static final String OPEN_WITH = "Open With";
+		public static final String MAVEN_CONTEXT_MENU_ITEM = "Maven";
+		public static final String GRADLE_CONTEXT_MENU_ITEM = "Gradle";
+		public static final String CUT_CONTEXT_MENU_ITEM = "Cut";
 		
 		//Project type labels
 		public static final String PROJECT_NAME = "Project name:";
@@ -49,6 +53,10 @@ public class QuarkusLabels {
 		public static final String VERSION = "Version:";
 		public static final String REST_CLASS_NAME = "Class name:";
 		public static final String REST_PATH = "Path:";
+		public static final String UPDATE_MAVEN_PROJECT = "Update Project...";
+		
+		//Gradle labels
+		public static final String REFRESH_GRADLE_PROJECT = "Refresh Gradle Project";
 		
 		//Extension selection labels
 		public static final String EXTENSIONS_CATEGORIES = "Categories";
@@ -60,5 +68,9 @@ public class QuarkusLabels {
 		//Run Configuration labels
 		public static final String QUARKUS_APPLICATION_TREE_ITEM = "Quarkus Application";
 		public static final String CONFIGURATION = "Configuration";
+		
+		//Text editors labels
+		public static final String GENERIC_TEXT_EDITOR = "Generic Text Editor";
+		public static final String TEXT_EDITOR = "Text Editor";
 	}
 }


### PR DESCRIPTION
https://quarkus.io/blog/quarkus-1-3-1-final-released/

Created AbstractCreateNewProjectTest ,changed CreateNewProjectTest,
InstallQuarkusExtensionTest and
QuarkusLabels. Added check jdk for
CreateNewQuarkusConfiguration(Gradle|Maven)Test.

Signed-off-by: olkornii <olkornii@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
