### PR TITLE
JBIDE-27093: Quarkus application.properties should be open with Gener…

### DIFF
--- a/plugins/org.jboss.tools.quarkus.lsp4e/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/META-INF/MANIFEST.MF
@@ -25,7 +25,8 @@ Require-Bundle: org.eclipse.lsp4e,
  org.jsoup;bundle-version="1.8.3",
  org.eclipse.ui,
  org.jboss.tools.foundation.ui,
- org.apache.commons.lang3
+ org.apache.commons.lang3,
+ org.eclipse.ui.ide
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.jboss.tools.quarkus.lsp4e
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.tools.quarkus.lsp4e/plugin.xml
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/plugin.xml
@@ -68,5 +68,12 @@
             commandId="quarkus.command.open.uri">
       </handler>
    </extension>
+   <extension
+         point="org.eclipse.ui.ide.editorAssociationOverride">
+      <editorAssociationOverride
+            class="org.jboss.tools.quarkus.lsp4e.internal.ui.QuarkusDefaultEditorAssociationOverride"
+            id="org.jboss.tools.quarkus.lsp4e.editorAssociationOverride">
+      </editorAssociationOverride>
+   </extension>
         
 </plugin>

--- a/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/internal/ui/QuarkusDefaultEditorAssociationOverride.java
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/internal/ui/QuarkusDefaultEditorAssociationOverride.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.quarkus.lsp4e.internal.ui;
+
+import org.eclipse.core.runtime.content.IContentType;
+import org.eclipse.ui.IEditorDescriptor;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorRegistry;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IEditorAssociationOverride;
+
+/**
+ * @author Red Hat Developers
+ * 
+ * As the JBoss Tools Properties editor is the default for properties file, this extension
+ * will make sure that for application.properties files, the generic editor is choosen.
+ */
+public class QuarkusDefaultEditorAssociationOverride implements IEditorAssociationOverride {
+
+	@Override
+	public IEditorDescriptor[] overrideEditors(IEditorInput editorInput, IContentType contentType,
+	        IEditorDescriptor[] editorDescriptors) {
+		return editorDescriptors;
+	}
+
+	@Override
+	public IEditorDescriptor[] overrideEditors(String fileName, IContentType contentType,
+	        IEditorDescriptor[] editorDescriptors) {
+		return editorDescriptors;
+	}
+
+	@Override
+	public IEditorDescriptor overrideDefaultEditor(IEditorInput editorInput, IContentType contentType,
+	        IEditorDescriptor editorDescriptor) {
+		return overrideDefaultEditor(editorInput.getName(), contentType, editorDescriptor);
+	}
+
+	@Override
+	public IEditorDescriptor overrideDefaultEditor(String fileName, IContentType contentType,
+	        IEditorDescriptor editorDescriptor) {
+		if (isOwnContenType(contentType)) {
+			return genericEditorDescriptor();
+		}
+		return editorDescriptor;
+	}
+
+	private IEditorDescriptor genericEditorDescriptor() {
+		IEditorRegistry editorReg = PlatformUI.getWorkbench()
+				.getEditorRegistry();
+		return editorReg.findEditor("org.eclipse.ui.genericeditor.GenericEditor");
+	}
+
+	private boolean isOwnContenType(IContentType contentType) {
+		return contentType != null && "org.jboss.tools.quarkus.lsp4e".equals(contentType.getId());
+	}
+}


### PR DESCRIPTION
…ic text editor by default

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
