### PR TITLE
JBIDE-27255: Ensure jbosstools-quarkus tests are run against https://…

### DIFF
--- a/itests/org.jboss.tools.quarkus.integration.tests/build.properties
+++ b/itests/org.jboss.tools.quarkus.integration.tests/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 src.includes = *
 src.excludes = src/
 bin.includes = META-INF/,\
-               plugin.properties
+               plugin.properties,\
+               plugin.xml

--- a/itests/org.jboss.tools.quarkus.integration.tests/plugin.xml
+++ b/itests/org.jboss.tools.quarkus.integration.tests/plugin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.reddeer.junit.before.test">
+         <client class="org.jboss.tools.quarkus.integration.tests.UseStageCodeQuarkusIO"/>
+   </extension>
+
+</plugin>

--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/QuarkusIntegrationTests.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/QuarkusIntegrationTests.java
@@ -10,9 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.integration.tests;
 
-import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_ENDPOINT_URL_PROPERTY_NAME;
-import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_ENDPOINT_URL_TEST;
-
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.tools.quarkus.integration.tests.common.PerspectiveTest;
 import org.jboss.tools.quarkus.integration.tests.content.assistant.ApplicationPropertiesContentAssistTest;
@@ -21,7 +18,6 @@ import org.jboss.tools.quarkus.integration.tests.launch.configuration.CreateNewQ
 import org.jboss.tools.quarkus.integration.tests.launch.configuration.CreateNewQuarkusConfigurationMavenTest;
 import org.jboss.tools.quarkus.integration.tests.project.CreateNewProjectTest;
 import org.jboss.tools.quarkus.integration.tests.project.InstallQuarkusExtensionTest;
-import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
 
@@ -42,9 +38,4 @@ import org.junit.runners.Suite.SuiteClasses;
 	
 })
 public class QuarkusIntegrationTests {
-	@BeforeClass
-	public static void setup() {
-		System.setProperty(CODE_ENDPOINT_URL_PROPERTY_NAME, CODE_ENDPOINT_URL_TEST);
-	}
-	
 }

--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/UseStageCodeQuarkusIO.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/UseStageCodeQuarkusIO.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.quarkus.integration.tests;
+
+import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_ENDPOINT_URL_PROPERTY_NAME;
+import static org.jboss.tools.quarkus.core.QuarkusCoreConstants.CODE_ENDPOINT_URL_TEST;
+
+import org.eclipse.reddeer.junit.extensionpoint.IBeforeTest;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
+
+/**
+ * @author Red Hat Developers
+ *
+ */
+public class UseStageCodeQuarkusIO implements IBeforeTest {
+
+	@Override
+	public long getPriority() {
+		return Long.MAX_VALUE;
+	}
+
+	@Override
+	public void runBeforeTestClass(String config, TestClass testClass) {
+		System.setProperty(CODE_ENDPOINT_URL_PROPERTY_NAME, CODE_ENDPOINT_URL_TEST);
+	}
+
+	@Override
+	public void runBeforeTest(String config, Object target, FrameworkMethod method) {
+	}
+
+	@Override
+	public boolean hasToRun() {
+		return true;
+	}
+}


### PR DESCRIPTION
…stage.code.quarkus.io/

- Fixed integration tests

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
