### PR TITLE
JBIDE-27283: Run configuration seems to trigger build for all projects

### DIFF
--- a/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/launch/LaunchUtils.java
+++ b/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/launch/LaunchUtils.java
@@ -35,6 +35,7 @@ public class LaunchUtils {
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 		workingCopy.setAttribute(IExternalToolConstants.ATTR_LOCATION, ProjectUtils.getToolSupport(project).getScriptPath().toOSString());
 		workingCopy.setAttribute(IExternalToolConstants.ATTR_WORKING_DIRECTORY, project.getLocation().toOSString());
+		workingCopy.setAttribute(IExternalToolConstants.ATTR_BUILD_SCOPE, "${projects:" + project.getName() + "}");
 		workingCopy.setAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, Collections.singletonMap("JAVA_HOME", ProjectUtils.getJavaHome(project)));
 		if (ProjectUtils.isMavenProject(project)) {
 			workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "compile quarkus:dev");


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
