### PR TITLE
JBIDE-27325: jbosstools-quarkus is using own jackson jars, use from TP

### DIFF
--- a/plugins/org.jboss.tools.quarkus.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.runtime/META-INF/MANIFEST.MF
@@ -7,10 +7,7 @@ Bundle-SymbolicName: org.jboss.tools.quarkus.runtime
 Bundle-Version: 1.1.0.qualifier
 Automatic-Module-Name: org.jboss.tools.quarkus.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: lib/jackson-annotations-2.9.8.jar,
- lib/jackson-core-2.9.8.jar,
- lib/jackson-databind-2.9.8.jar,
- lib/maven-model-3.6.0.jar,
+Bundle-ClassPath: lib/maven-model-3.6.0.jar,
  lib/plexus-utils-3.1.1.jar,
  lib/quarkus-development-mode-0.25.0.jar,
  lib/quarkus-devtools-common-0.25.0.jar,
@@ -23,3 +20,6 @@ Export-Package: io.quarkus.cli.commands,
  io.quarkus.generators,
  io.quarkus.maven.utilities,
  io.quarkus.remotedev
+Require-Bundle: com.fasterxml.jackson.core.jackson-annotations,
+ com.fasterxml.jackson.core.jackson-core,
+ com.fasterxml.jackson.core.jackson-databind

--- a/plugins/org.jboss.tools.quarkus.runtime/pom.xml
+++ b/plugins/org.jboss.tools.quarkus.runtime/pom.xml
@@ -77,21 +77,6 @@
                             <artifactId>plexus-utils</artifactId>
                             <version>${plexus.version}</version>
                         </artifactItem>
-                        <artifactItem>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-annotations</artifactId>
-                            <version>${jackson.version}</version>
-                        </artifactItem>
-                        <artifactItem>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-core</artifactId>
-                            <version>${jackson.version}</version>
-                        </artifactItem>
-                        <artifactItem>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-databind</artifactId>
-                            <version>${jackson.version}</version>
-                        </artifactItem>
                     </artifactItems>
                     <skip>false</skip>
                     <outputDirectory>${lib.dir}</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     <packaging>pom</packaging>
 
     <properties>
-        <jackson.version>2.9.8</jackson.version>
         <maven.version>3.6.0</maven.version>
         <plexus.version>3.1.1</plexus.version>
         <quarkus.version>0.25.0</quarkus.version>


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
