### PR TITLE
JBIDE-27376: Missing requirement "com.redhat.microprofile.jdt.quarkus"

### DIFF
--- a/features/org.jboss.tools.quarkus.feature/feature.xml
+++ b/features/org.jboss.tools.quarkus.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.quarkus.feature"
       label="Quarkus Eclipse Feature"
-      version="1.1.0.qualifier">
+      version="1.2.0.qualifier">
 
    <description>
       The Eclipse plugins in this feature provide tooling for the Quarkus

--- a/features/org.jboss.tools.quarkus.feature/feature.xml
+++ b/features/org.jboss.tools.quarkus.feature/feature.xml
@@ -272,7 +272,7 @@ APPENDIX: How to apply the Apache License to your work.
          unpack="false"/>
 
    <plugin
-         id="com.redhat.microprofile.jdt.core"
+         id="org.eclipse.lsp4mp.jdt.core"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/features/org.jboss.tools.quarkus.feature/pom.xml
+++ b/features/org.jboss.tools.quarkus.feature/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>features</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus.features</groupId>

--- a/features/org.jboss.tools.quarkus.test.feature/feature.xml
+++ b/features/org.jboss.tools.quarkus.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.quarkus.test.feature"
       label="Quarkus Eclipse Feature Test"
-      version="1.1.0.qualifier">
+      version="1.2.0.qualifier">
 
    <description>
       The Eclipse plugins in this feature provide tooling for the Quarkus

--- a/features/org.jboss.tools.quarkus.test.feature/pom.xml
+++ b/features/org.jboss.tools.quarkus.test.feature/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>features</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus.features</groupId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools</groupId>
         <artifactId>quarkus</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus</groupId>

--- a/itests/org.jboss.tools.quarkus.integration.tests/META-INF/MANIFEST.MF
+++ b/itests/org.jboss.tools.quarkus.integration.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Quarkus Integration Tests
 Bundle-SymbolicName: org.jboss.tools.quarkus.integration.tests;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Require-Bundle: org.eclipse.reddeer.go,
  org.jboss.tools.quarkus.reddeer,
  org.eclipse.m2e.editor.xml,

--- a/itests/org.jboss.tools.quarkus.integration.tests/pom.xml
+++ b/itests/org.jboss.tools.quarkus.integration.tests/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.jboss.tools.quarkus</groupId>
 		<artifactId>itests</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>1.2.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.jboss.tools.quarkus.itests</groupId>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.tools</groupId>
         <artifactId>quarkus</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
 	<groupId>org.jboss.tools.quarkus</groupId>

--- a/plugins/org.jboss.tools.quarkus.cheatsheet/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.cheatsheet/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Copyright: Copyright (c) 2019 Red Hat, Inc.
 Bundle-ManifestVersion: 2
 Bundle-Name: Quarkus Eclipse Cheatsheet Plugin
 Bundle-SymbolicName: org.jboss.tools.quarkus.cheatsheet;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Automatic-Module-Name: org.jboss.tools.quarkus.cheatsheet
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.jboss.tools.quarkus.ui,

--- a/plugins/org.jboss.tools.quarkus.cheatsheet/pom.xml
+++ b/plugins/org.jboss.tools.quarkus.cheatsheet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>plugins</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus.plugins</groupId>

--- a/plugins/org.jboss.tools.quarkus.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Copyright: Copyright (c) 2019 Red Hat, Inc.
 Bundle-ManifestVersion: 2
 Bundle-Name: Quarkus Eclipse Core Plugin
 Bundle-SymbolicName: org.jboss.tools.quarkus.core;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Automatic-Module-Name: org.jboss.tools.quarkus.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.jboss.tools.quarkus.runtime,

--- a/plugins/org.jboss.tools.quarkus.core/pom.xml
+++ b/plugins/org.jboss.tools.quarkus.core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>plugins</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus.plugins</groupId>

--- a/plugins/org.jboss.tools.quarkus.lsp4e/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.jboss.tools.quarkus.lsp4e;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Require-Bundle: org.eclipse.lsp4e,
  org.eclipse.core.runtime,
  org.eclipse.ui.workbench,

--- a/plugins/org.jboss.tools.quarkus.lsp4e/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.lsp4e,
  com.google.gson,
  org.eclipse.jdt.core.manipulation,
  org.eclipse.jdt.ui,
- com.redhat.microprofile.jdt.core,
+ org.eclipse.lsp4mp.jdt.core,
  org.jsoup;bundle-version="1.8.3",
  org.eclipse.ui,
  org.jboss.tools.foundation.ui,
@@ -32,7 +32,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.jboss.tools.quarkus.lsp4e
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
- server/com.redhat.microprofile.ls-uber.jar,
+ server/org.eclipse.lsp4mp.ls-uber.jar,
  lib/remark.jar
 Bundle-Activator: org.jboss.tools.quarkus.lsp4e.QuarkusLSPPlugin
 Export-Package: org.jboss.tools.quarkus.lsp4e

--- a/plugins/org.jboss.tools.quarkus.lsp4e/pom.xml
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>plugins</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus.plugins</groupId>

--- a/plugins/org.jboss.tools.quarkus.lsp4e/pom.xml
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/pom.xml
@@ -33,7 +33,6 @@
     <packaging>eclipse-plugin</packaging>
 
     <properties>
-        <quarkus-ls.version>0.8.0-SNAPSHOT</quarkus-ls.version>
         <enforcer.skip>true</enforcer.skip>
     </properties>
 
@@ -53,9 +52,9 @@
                                 <outputDirectory>${basedir}/server/</outputDirectory>
                                 <artifactItems>
                                     <artifactItem>
-                                        <groupId>com.redhat.microprofile</groupId>
-                                        <artifactId>com.redhat.microprofile.ls</artifactId>
-                                        <version>${quarkus-ls.version}</version>
+                                        <groupId>org.eclipse.lsp4mp</groupId>
+                                        <artifactId>org.eclipse.lsp4mp.ls</artifactId>
+                                        <version>${lsp4mp-ls.version}</version>
                                         <classifier>uber</classifier>
                                     </artifactItem>
                                     <artifactItem>

--- a/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/QuarkusLanguageClient.java
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/QuarkusLanguageClient.java
@@ -27,24 +27,23 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeActionParams;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeLensParams;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsParams;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaHoverParams;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaProjectLabelsParams;
+import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
+import org.eclipse.lsp4mp.commons.MicroProfileProjectInfoParams;
+import org.eclipse.lsp4mp.commons.MicroProfilePropertyDefinitionParams;
+import org.eclipse.lsp4mp.commons.ProjectLabelInfoEntry;
+import org.eclipse.lsp4mp.jdt.core.IMicroProfilePropertiesChangedListener;
+import org.eclipse.lsp4mp.jdt.core.MicroProfileCorePlugin;
+import org.eclipse.lsp4mp.jdt.core.ProjectLabelManager;
+import org.eclipse.lsp4mp.jdt.core.PropertiesManager;
+import org.eclipse.lsp4mp.jdt.core.PropertiesManagerForJava;
+import org.eclipse.lsp4mp.ls.api.MicroProfileLanguageClientAPI;
+import org.eclipse.lsp4mp.ls.api.MicroProfileLanguageServerAPI;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
-
-import com.redhat.microprofile.commons.MicroProfileJavaCodeActionParams;
-import com.redhat.microprofile.commons.MicroProfileJavaCodeLensParams;
-import com.redhat.microprofile.commons.MicroProfileJavaDiagnosticsParams;
-import com.redhat.microprofile.commons.MicroProfileJavaHoverParams;
-import com.redhat.microprofile.commons.MicroProfileJavaProjectLabelsParams;
-import com.redhat.microprofile.commons.MicroProfileProjectInfo;
-import com.redhat.microprofile.commons.MicroProfileProjectInfoParams;
-import com.redhat.microprofile.commons.MicroProfilePropertyDefinitionParams;
-import com.redhat.microprofile.commons.ProjectLabelInfoEntry;
-import com.redhat.microprofile.jdt.core.IMicroProfilePropertiesChangedListener;
-import com.redhat.microprofile.jdt.core.MicroProfileCorePlugin;
-import com.redhat.microprofile.jdt.core.ProjectLabelManager;
-import com.redhat.microprofile.jdt.core.PropertiesManager;
-import com.redhat.microprofile.jdt.core.PropertiesManagerForJava;
-import com.redhat.microprofile.ls.api.MicroProfileLanguageClientAPI;
-import com.redhat.microprofile.ls.api.MicroProfileLanguageServerAPI;
 
 /**
  * LSP4E Quarkus language client.

--- a/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/QuarkusLanguageServer.java
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/QuarkusLanguageServer.java
@@ -45,7 +45,7 @@ public class QuarkusLanguageServer extends ProcessStreamConnectionProvider {
 		commands.add("-classpath");
 		try {
 			commands.add(computeClasspath());
-			commands.add("com.redhat.microprofile.ls.MicroProfileServerLauncher");
+			commands.add("org.eclipse.lsp4mp.ls.MicroProfileServerLauncher");
 			setCommands(commands);
 			setWorkingDirectory(System.getProperty("user.dir"));
 		} catch (IOException e) {
@@ -56,7 +56,7 @@ public class QuarkusLanguageServer extends ProcessStreamConnectionProvider {
 	
 	private String computeClasspath() throws IOException {
 		StringBuilder builder = new StringBuilder();
-		URL url = FileLocator.toFileURL(getClass().getResource("/server/com.redhat.microprofile.ls-uber.jar"));
+		URL url = FileLocator.toFileURL(getClass().getResource("/server/org.eclipse.lsp4mp.ls-uber.jar"));
 		builder.append(new java.io.File(url.getPath()).getAbsolutePath());
 		builder.append(File.pathSeparatorChar);
 		url = FileLocator.toFileURL(getClass().getResource("/server/com.redhat.quarkus.ls.jar"));

--- a/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/internal/JDTUtilsImpl.java
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/internal/JDTUtilsImpl.java
@@ -24,12 +24,10 @@ import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IOpenable;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.ui.JavadocContentAccess;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
-
-import com.redhat.microprofile.commons.DocumentFormat;
-import com.redhat.microprofile.jdt.core.utils.IJDTUtils;
+import org.eclipse.lsp4mp.commons.DocumentFormat;
+import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
 
 public class JDTUtilsImpl implements IJDTUtils {
 	private static final IJDTUtils INSTANCE = new JDTUtilsImpl();

--- a/plugins/org.jboss.tools.quarkus.runtime/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Copyright: Copyright (c) 2019 Red Hat, Inc.
 Bundle-ManifestVersion: 2
 Bundle-Name: Quarkus Eclipse Runtime Plugin
 Bundle-SymbolicName: org.jboss.tools.quarkus.runtime
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Automatic-Module-Name: org.jboss.tools.quarkus.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: lib/maven-model-3.6.0.jar,

--- a/plugins/org.jboss.tools.quarkus.runtime/pom.xml
+++ b/plugins/org.jboss.tools.quarkus.runtime/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>plugins</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.tools.quarkus.plugins</groupId>

--- a/plugins/org.jboss.tools.quarkus.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.quarkus.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Copyright: Copyright (c) 2019 Red Hat, Inc.
 Bundle-ManifestVersion: 2
 Bundle-Name: Quarkus Eclipse UI Plugin
 Bundle-SymbolicName: org.jboss.tools.quarkus.ui;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Automatic-Module-Name: org.jboss.tools.quarkus.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.jboss.tools.quarkus.core,

--- a/plugins/org.jboss.tools.quarkus.ui/pom.xml
+++ b/plugins/org.jboss.tools.quarkus.ui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>plugins</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus.plugins</groupId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.tools</groupId>
         <artifactId>quarkus</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,18 @@
         <plexus.version>3.1.1</plexus.version>
         <quarkus.version>0.25.0</quarkus.version>
 		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-quarkus.git</tycho.scmUrl>
-        <quarkus-jdt-site>https://download.jboss.org/jbosstools/vscode/snapshots/builds/microprofile-jdt/latest/all/repo/</quarkus-jdt-site>
-		<!--<quarkus-jdt-site>https://download.jboss.org/jbosstools/vscode/stable/builds/microprofile-jdt/latest/all/repo/</quarkus-jdt-site>-->
+		<lsp4mp-jdt-site>https://download.eclipse.org/lsp4mp/snapshots/0.0.9/repository</lsp4mp-jdt-site>
+        <quarkus-jdt-site>https://download.jboss.org/jbosstools/vscode/snapshots/builds/quarkus-jdt/latest/all/repo/</quarkus-jdt-site>
+        <quarkus-ls.version>0.9.0-SNAPSHOT</quarkus-ls.version>
+        <lsp4mp-ls.version>0.9.0-SNAPSHOT</lsp4mp-ls.version>
     </properties>
 
 	<repositories>
+		<repository>
+			<id>lsp4mp-jdt</id>
+			<layout>p2</layout>
+			<url>${lsp4mp-jdt-site}</url>
+		</repository>
 		<repository>
 			<id>quarkus-jdt</id>
 			<layout>p2</layout>
@@ -51,6 +58,10 @@
 			<id>jbosstools-base</id>
 			<layout>p2</layout>
 			<url>${jbosstools-base-site}</url>
+		</repository>
+		<repository>
+		  <id>lsp4mp-snapshots</id>
+		  <url>https://repo.eclipse.org/content/repositories/lsp4mp-snapshots</url>
 		</repository>		
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	</parent>
 
     <artifactId>quarkus</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools</groupId>
         <artifactId>quarkus</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus</groupId>

--- a/test-framework/org.jboss.tools.quarkus.reddeer/META-INF/MANIFEST.MF
+++ b/test-framework/org.jboss.tools.quarkus.reddeer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for quarkus UI Tests
 Bundle-SymbolicName: org.jboss.tools.quarkus.reddeer
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Require-Bundle: 
  org.jboss.tools.quarkus.ui,
  org.eclipse.reddeer.go

--- a/test-framework/org.jboss.tools.quarkus.reddeer/pom.xml
+++ b/test-framework/org.jboss.tools.quarkus.reddeer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>test-framework</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus.test-framework</groupId>

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.jboss.tools</groupId>
         <artifactId>quarkus</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus</groupId>

--- a/tests/org.jboss.tools.quarkus.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.quarkus.core.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Copyright: Copyright (c) 2019 Red Hat, Inc.
 Bundle-ManifestVersion: 2
 Bundle-Name: Quarkus Eclipse Core Test Fragment
 Bundle-SymbolicName: org.jboss.tools.quarkus.core.test
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Fragment-Host: org.jboss.tools.quarkus.core
 Automatic-Module-Name: org.jboss.tools.quarkus.core.test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.jboss.tools.quarkus.core.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.core.test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>tests</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.tools.quarkus.tests</groupId>

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Quarkus Eclipse LSP4E Test Fragment
 Bundle-SymbolicName: org.jboss.tools.quarkus.lsp4e.test
 Fragment-Host: org.jboss.tools.quarkus.lsp4e
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Automatic-Module-Name: org.jboss.tools.quarkus.lsp4e.test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.lsp4mp.jdt.core,

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Fragment-Host: org.jboss.tools.quarkus.lsp4e
 Bundle-Version: 1.1.0.qualifier
 Automatic-Module-Name: org.jboss.tools.quarkus.lsp4e.test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: com.redhat.microprofile.jdt.core,
+Require-Bundle: org.eclipse.lsp4mp.jdt.core,
  org.junit,
  com.redhat.microprofile.jdt.quarkus,
- com.redhat.microprofile.jdt.test
+ org.eclipse.lsp4mp.jdt.test

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>tests</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.tools.quarkus.tests</groupId>

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/pom.xml
@@ -76,7 +76,7 @@
                     <dependency-resolution>
                         <extraRequirements>
                             <requirement>
-                                <id>com.redhat.microprofile.jdt.test</id>
+                                <id>org.eclipse.lsp4mp.jdt.test</id>
                                 <versionRange>0.0.0</versionRange>
                                 <type>eclipse-plugin</type>
                             </requirement>

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTConfigItemIntBoolDefaultValueTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTConfigItemIntBoolDefaultValueTest.java
@@ -1,9 +1,8 @@
 package org.jboss.tools.quarkus.lsp4e.core;
 
+import org.eclipse.lsp4mp.jdt.core.ConfigItemIntBoolDefaultValueTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
-
-import com.redhat.microprofile.jdt.core.ConfigItemIntBoolDefaultValueTest;
 
 public class JDTConfigItemIntBoolDefaultValueTest extends ConfigItemIntBoolDefaultValueTest {
 	@BeforeClass

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTGenerateAllPropertiesAndDefinition.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTGenerateAllPropertiesAndDefinition.java
@@ -10,10 +10,9 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core;
 
+import org.eclipse.lsp4mp.jdt.core.GenerateAllPropertiesAndDefinition;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
-
-import com.redhat.microprofile.jdt.core.GenerateAllPropertiesAndDefinition;
 
 /**
  * @author Red Hat Developers

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTJavaHoverTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTJavaHoverTest.java
@@ -10,10 +10,9 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core;
 
+import org.eclipse.lsp4mp.jdt.core.JavaHoverTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
-
-import com.redhat.microprofile.jdt.core.JavaHoverTest;
 
 /**
  * @author Red Hat Developers

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTMicroProfileConfigPropertyTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTMicroProfileConfigPropertyTest.java
@@ -10,10 +10,9 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core;
 
+import org.eclipse.lsp4mp.jdt.core.MicroProfileConfigPropertyTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
-
-import com.redhat.microprofile.jdt.core.MicroProfileConfigPropertyTest;
 
 /**
  * @author Red Hat Developers

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/faulttolerance/JDTMicroProfileFaultToleranceTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/faulttolerance/JDTMicroProfileFaultToleranceTest.java
@@ -10,11 +10,10 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core.faulttolerance;
 
+import org.eclipse.lsp4mp.jdt.core.faulttolerance.MicroProfileFaultToleranceTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-
-import com.redhat.microprofile.jdt.core.faulttolerance.MicroProfileFaultToleranceTest;
 
 /**
  * @author Red Hat Developers

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/health/JDTJavaDiagnosticsMicroProfileHealthTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/health/JDTJavaDiagnosticsMicroProfileHealthTest.java
@@ -10,11 +10,10 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core.health;
 
+import org.eclipse.lsp4mp.jdt.core.health.JavaDiagnosticsMicroProfileHealthTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-
-import com.redhat.microprofile.jdt.core.health.JavaDiagnosticsMicroProfileHealthTest;
 
 /**
  * @author Red Hat Developers

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/jaxrs/JDTJaxRsCodeLensTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/jaxrs/JDTJaxRsCodeLensTest.java
@@ -10,10 +10,9 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core.jaxrs;
 
+import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsCodeLensTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
-
-import com.redhat.microprofile.jdt.core.jaxrs.JaxRsCodeLensTest;
 
 /**
  * @author Red Hat Developers

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/metrics/JDTMicroProfileMetricsTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/metrics/JDTMicroProfileMetricsTest.java
@@ -10,10 +10,9 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core.metrics;
 
+import org.eclipse.lsp4mp.jdt.core.metrics.MicroProfileMetricsTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
-
-import com.redhat.microprofile.jdt.core.metrics.MicroProfileMetricsTest;
 
 /**
  * @author Red Hat Developers

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/opentracing/JDTMicroProfileOpenTracingTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/opentracing/JDTMicroProfileOpenTracingTest.java
@@ -10,10 +10,9 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core.opentracing;
 
+import org.eclipse.lsp4mp.jdt.core.opentracing.MicroProfileOpenTracingTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
-
-import com.redhat.microprofile.jdt.core.opentracing.MicroProfileOpenTracingTest;
 
 /**
  * @author Red Hat Developers

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/restclient/JDTJavaCodeLensMicroProfileRestClientTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/restclient/JDTJavaCodeLensMicroProfileRestClientTest.java
@@ -10,10 +10,9 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core.restclient;
 
+import org.eclipse.lsp4mp.jdt.core.restclient.JavaCodeLensMicroProfileRestClientTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
-
-import com.redhat.microprofile.jdt.core.restclient.JavaCodeLensMicroProfileRestClientTest;
 
 /**
  * @author Red Hat Developers

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/restclient/JDTJavaDiagnosticsMicroProfileRestClientTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/restclient/JDTJavaDiagnosticsMicroProfileRestClientTest.java
@@ -10,11 +10,10 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core.restclient;
 
+import org.eclipse.lsp4mp.jdt.core.restclient.JavaDiagnosticsMicroProfileRestClientTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
-
-import com.redhat.microprofile.jdt.core.restclient.JavaDiagnosticsMicroProfileRestClientTest;
 
 /**
  * @author Red Hat Developers

--- a/tests/org.jboss.tools.quarkus.runtime.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.quarkus.runtime.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Copyright: Copyright (c) 2019 Red Hat, Inc.
 Bundle-ManifestVersion: 2
 Bundle-Name: Quarkus Eclipse Runtime Test Fragment
 Bundle-SymbolicName: org.jboss.tools.quarkus.runtime.test
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Fragment-Host: org.jboss.tools.quarkus.runtime
 Automatic-Module-Name: org.jboss.tools.quarkus.runtime.test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.jboss.tools.quarkus.runtime.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.runtime.test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>tests</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus.tests</groupId>

--- a/tests/org.jboss.tools.quarkus.ui.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.quarkus.ui.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Copyright: Copyright (c) 2019 Red Hat, Inc.
 Bundle-ManifestVersion: 2
 Bundle-Name: Test
 Bundle-SymbolicName: org.jboss.tools.quarkus.ui.test
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Fragment-Host: org.jboss.tools.quarkus.ui
 Automatic-Module-Name: org.jboss.tools.quarkus.ui.test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/org.jboss.tools.quarkus.ui.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.ui.test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools.quarkus</groupId>
         <artifactId>tests</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus.tests</groupId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss.tools</groupId>
         <artifactId>quarkus</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>org.jboss.tools.quarkus</groupId>


### PR DESCRIPTION
- Switch to 0.9.0 and LSP4MP

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
