### PR TITLE
JBIDE-27425: quarkus build fails on Java8

### DIFF
--- a/tests/org.jboss.tools.quarkus.lsp4e.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/META-INF/MANIFEST.MF
@@ -11,4 +11,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.lsp4mp.jdt.core,
  org.junit,
  com.redhat.microprofile.jdt.quarkus,
+ com.redhat.microprofile.jdt.quarkus.test,
  org.eclipse.lsp4mp.jdt.test

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/pom.xml
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/pom.xml
@@ -40,7 +40,8 @@
         <repository>
             <id>jdt.ls.p2</id>
             <layout>p2</layout>
-            <url>http://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
+            <!--<url>http://download.eclipse.org/jdtls/snapshots/repository/latest/</url>-->
+			<url>https://download.eclipse.org/jdtls/milestones/0.57.0/repository/</url>
         </repository>
         <repository>
             <id>jdt.ls.maven</id>

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTConfigItemIntBoolDefaultValueTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTConfigItemIntBoolDefaultValueTest.java
@@ -1,8 +1,9 @@
 package org.jboss.tools.quarkus.lsp4e.core;
 
-import org.eclipse.lsp4mp.jdt.core.ConfigItemIntBoolDefaultValueTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
+
+import com.redhat.microprofile.jdt.quarkus.ConfigItemIntBoolDefaultValueTest;
 
 public class JDTConfigItemIntBoolDefaultValueTest extends ConfigItemIntBoolDefaultValueTest {
 	@BeforeClass

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTMicroProfileConfigPropertyTest.java
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/src/main/java/org/jboss/tools/quarkus/lsp4e/core/JDTMicroProfileConfigPropertyTest.java
@@ -10,9 +10,10 @@
  ******************************************************************************/
 package org.jboss.tools.quarkus.lsp4e.core;
 
-import org.eclipse.lsp4mp.jdt.core.MicroProfileConfigPropertyTest;
 import org.jboss.tools.quarkus.lsp4e.internal.JDTUtilsImpl;
 import org.junit.BeforeClass;
+
+import com.redhat.microprofile.jdt.quarkus.MicroProfileConfigPropertyTest;
 
 /**
  * @author Red Hat Developers


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
