### PR TITLE
revert as bundle is not present in TP yet and fails in downstream builds

### DIFF
--- a/features/org.jboss.tools.quarkus.feature/feature.xml
+++ b/features/org.jboss.tools.quarkus.feature/feature.xml
@@ -239,7 +239,6 @@ APPENDIX: How to apply the Apache License to your work.
 
    <requires>
       <import plugin="org.eclipse.lsp4mp.jdt.core"/>
-      <import plugin="com.redhat.microprofile.jdt.quarkus"/>
    </requires>
 
    <plugin
@@ -271,6 +270,13 @@ APPENDIX: How to apply the Apache License to your work.
 
    <plugin
          id="org.jboss.tools.quarkus.lsp4e"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="com.redhat.microprofile.jdt.quarkus"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/tests/org.jboss.tools.quarkus.lsp4e.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.quarkus.lsp4e.test/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Require-Bundle: org.eclipse.lsp4mp.jdt.core,
  com.redhat.microprofile.jdt.quarkus,
  com.redhat.microprofile.jdt.quarkus.test,
  org.eclipse.lsp4mp.jdt.test
+Bundle-Vendor: Red Hat


### PR DESCRIPTION
Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
