### PR TITLE
JBIDE-27462: YAML code assist works only once

### DIFF
--- a/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/internal/yaml/SchemaRegistry.java
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/internal/yaml/SchemaRegistry.java
@@ -89,9 +89,9 @@ public class SchemaRegistry implements IMicroProfilePropertiesChangedListener, I
           schemaEntry = new MutablePair<>(schemaFile, Boolean.TRUE);
           schemas.put(project, schemaEntry);
         }
-        if (sendToServer) {
-          sendInitialize();
-        }
+      }
+      if (sendToServer) {
+        sendInitialize();
       }
     } catch (CoreException | IOException e) {
       QuarkusLSPPlugin.logException(e.getLocalizedMessage(), e);


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
