### PR TITLE
JBIDE-27603: NPE when Quarkus configuration project is closed or deleted

### DIFF
--- a/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/launch/LaunchUtils.java
+++ b/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/core/launch/LaunchUtils.java
@@ -36,15 +36,16 @@ public class LaunchUtils {
 		String profileName = workingCopy.getAttribute(QuarkusCoreConstants.ATTR_PROFILE_NAME, "");
 		String suffix = profileName.length() > 0 ? " -Dquarkus.profile=" + profileName:"";
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
-		workingCopy.setAttribute(IExternalToolConstants.ATTR_LOCATION, ProjectUtils.getToolSupport(project).getScriptPath().toOSString());
-		workingCopy.setAttribute(IExternalToolConstants.ATTR_WORKING_DIRECTORY, project.getLocation().toOSString());
-		workingCopy.setAttribute(IExternalToolConstants.ATTR_BUILD_SCOPE, "${projects:" + project.getName() + "}");
-		workingCopy.setAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, Collections.singletonMap("JAVA_HOME", ProjectUtils.getJavaHome(project)));
-		if (ProjectUtils.isMavenProject(project)) {
-			workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "compile quarkus:dev" + suffix);
-		} else {
-			workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "quarkusDev" + suffix);
+		if (project.exists() && project.isAccessible()) {
+			workingCopy.setAttribute(IExternalToolConstants.ATTR_LOCATION, ProjectUtils.getToolSupport(project).getScriptPath().toOSString());
+			workingCopy.setAttribute(IExternalToolConstants.ATTR_WORKING_DIRECTORY, project.getLocation().toOSString());
+			workingCopy.setAttribute(IExternalToolConstants.ATTR_BUILD_SCOPE, "${projects:" + project.getName() + "}");
+			workingCopy.setAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, Collections.singletonMap("JAVA_HOME", ProjectUtils.getJavaHome(project)));
+			if (ProjectUtils.isMavenProject(project)) {
+				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "compile quarkus:dev" + suffix);
+			} else {
+				workingCopy.setAttribute(IExternalToolConstants.ATTR_TOOL_ARGUMENTS, "quarkusDev" + suffix);
+			}
 		}
 	}
-
 }


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
