### PR TITLE
JBIDE-27713: quarkus build failing with 2021-03 TP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-quarkus.git</tycho.scmUrl>
         <quarkus-jdt-site>https://download.jboss.org/jbosstools/vscode/snapshots/builds/quarkus-jdt/latest/all/repo/</quarkus-jdt-site>
 		<lsp4mp-jdt-site>http://download.eclipse.org/lsp4mp/snapshots/0.2.0/repository/</lsp4mp-jdt-site>
-        <quarkus-ls.version>0.9.0-SNAPSHOT</quarkus-ls.version>
+        <quarkus-ls.version>0.10.0-SNAPSHOT</quarkus-ls.version>
         <lsp4mp-ls.version>0.2.0-SNAPSHOT</lsp4mp-ls.version>
         <!--
           Uncomment only if you need to use non released bits from LSP4MP or Quarkus LS in GA


### PR DESCRIPTION
Use latest quarlus-ls

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
