### PR TITLE
JBIDE-27738: Allow environment variables for Quarkus configurations

### DIFF
--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/launch/QuarkusLaunchConfigurationTabGroup.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/launch/QuarkusLaunchConfigurationTabGroup.java
@@ -18,13 +18,13 @@ package org.jboss.tools.quarkus.ui.launch;
 
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.CommonTab;
+import org.eclipse.debug.ui.EnvironmentTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
-import org.eclipse.debug.ui.ILaunchConfigurationTab;
 
 public class QuarkusLaunchConfigurationTabGroup extends AbstractLaunchConfigurationTabGroup {
 
 	@Override
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-		setTabs(new ILaunchConfigurationTab[] { new QuarkusProjectTab(), new CommonTab() });
+		setTabs(new QuarkusProjectTab(), new EnvironmentTab(), new CommonTab());
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
           Uncomment only if you need to use non released bits from LSP4MP or Quarkus LS in GA
           in case of desynchronization between the projects
           -->
-        <!--<enforceExcludePatternExtras>|quarkus-ls.version|lsp4mp-ls.version</enforceExcludePatternExtras>-->
+        <enforceExcludePatternExtras>|quarkus-ls.version|lsp4mp-ls.version</enforceExcludePatternExtras>
     </properties>
 
 	<repositories>


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
