### PR TITLE
JBIDE-27799: added more time for loading microprofile, moved method for

### DIFF
--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/content/assistant/AbstractContentAssistantTest.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/content/assistant/AbstractContentAssistantTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractContentAssistantTest extends AbstractQuarkusTest {
 		checkProblemsView();
 	}
 
-	public ContentAssistant testContentAssistant(String projectName, String textForContentAssist) {
+	public static ContentAssistant testContentAssistant(String projectName, String textForContentAssist) {
 		new WorkbenchShell().setFocus();
 		new ProjectExplorer().selectProjects(projectName);
 		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
@@ -70,22 +70,9 @@ public abstract class AbstractContentAssistantTest extends AbstractQuarkusTest {
 		}
 		return true;
 	}
-
+	
 	public static TextEditor openFileWithTextEditor(String projectName, String textEditor) {
-
-		try {
-			new ProjectExplorer().getProject(projectName).getProjectItem(RESOURCE_PATH)
-					.getProjectItem(APPLICATION_PROPERTIES).openWith(textEditor);
-		} catch (org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException e) { // CRS need some time for
-																						// download microprofile...
-																						// when
-																						// application_properties
-																						// opens, sometimes it need
-																						// more then default 10
-																						// seconds
-		}
-		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
-		return new TextEditor(APPLICATION_PROPERTIES);
+		return openFileWithTextEditor(projectName, textEditor, RESOURCE_PATH, APPLICATION_PROPERTIES);
 	}
 
 	public static ContentAssistant openContentAssist(TextEditor editor) {

--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/RunProjectsOnOtherPorts.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/RunProjectsOnOtherPorts.java
@@ -14,11 +14,11 @@ package org.jboss.tools.quarkus.integration.tests.project;
 import static org.junit.Assert.fail;
 
 import org.eclipse.reddeer.common.matcher.RegexMatcher;
+import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.core.matcher.WithTextMatcher;
 import org.eclipse.reddeer.eclipse.debug.ui.launchConfigurations.RunConfigurationsDialog;
 import org.eclipse.reddeer.eclipse.ui.console.ConsoleView;
-import org.eclipse.reddeer.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.eclipse.reddeer.junit.runner.RedDeerSuite;
 import org.eclipse.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
@@ -93,12 +93,11 @@ public class RunProjectsOnOtherPorts extends AbstractLaunchConfigurationTest {
 	}
 
 	private void changeDebugPort() {
-		new ProjectExplorer().getProject(PROJECT_NAME_2).getProjectItem(RESOURCE_PATH)
-				.getProjectItem(APPLICATION_PROPERTIES).openWith(TextLabels.TEXT_EDITOR);
-		TextEditor editor = new TextEditor(APPLICATION_PROPERTIES);
+		TextEditor editor = openFileWithTextEditor(PROJECT_NAME_2, TextLabels.GENERIC_TEXT_EDITOR, RESOURCE_PATH,
+				APPLICATION_PROPERTIES);
 		editor.setText(DEBUG_PORT);
 		editor.save();
 		editor.close();
-		new WaitWhile(new JobIsRunning());
+		new WaitWhile(new JobIsRunning(), TimePeriod.LONG);
 	}
 }

--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/universal/methods/AbstractQuarkusTest.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/universal/methods/AbstractQuarkusTest.java
@@ -41,6 +41,7 @@ import org.eclipse.reddeer.swt.impl.menu.ContextMenuItem;
 import org.eclipse.reddeer.swt.impl.text.LabeledText;
 import org.eclipse.reddeer.workbench.core.condition.JobIsRunning;
 import org.eclipse.reddeer.workbench.handler.WorkbenchShellHandler;
+import org.eclipse.reddeer.workbench.impl.editor.TextEditor;
 import org.eclipse.reddeer.workbench.impl.shell.WorkbenchShell;
 import org.jboss.tools.quarkus.core.QuarkusCorePlugin;
 import org.jboss.tools.quarkus.reddeer.common.QuarkusLabels.TextLabels;
@@ -126,7 +127,7 @@ public abstract class AbstractQuarkusTest {
 		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
 	}
 
-	public void checkUrlContent(String should_be, String localhostPort) {
+	public static void checkUrlContent(String should_be, String localhostPort) {
 		URL localhost = null;
 		try {
 			localhost = new URL("http://localhost:" + localhostPort + "/hello");
@@ -176,6 +177,24 @@ public abstract class AbstractQuarkusTest {
 		} finally {
 			stream.close();
 		}
+	}
+
+	public static TextEditor openFileWithTextEditor(String projectName, String textEditorType, String resourcePath,
+			String fileName) {
+
+		try {
+			new ProjectExplorer().getProject(projectName).getProjectItem(resourcePath).getProjectItem(fileName)
+					.openWith(textEditorType);
+		} catch (org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException e) { // CRS need some time for
+																						// download microprofile...
+																						// when
+																						// application_properties
+																						// opens, sometimes it need
+																						// more then default 10
+																						// seconds
+		}
+		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
+		return new TextEditor(fileName);
 	}
 
 	@After

--- a/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/universal/methods/AbstractQuarkusTest.java
+++ b/itests/org.jboss.tools.quarkus.integration.tests/src/org/jboss/tools/quarkus/integration/tests/project/universal/methods/AbstractQuarkusTest.java
@@ -27,6 +27,7 @@ import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.util.List;
 
+import org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException;
 import org.eclipse.reddeer.common.wait.TimePeriod;
 import org.eclipse.reddeer.common.wait.WaitWhile;
 import org.eclipse.reddeer.eclipse.ui.dialogs.WizardNewFileCreationPage;
@@ -185,13 +186,13 @@ public abstract class AbstractQuarkusTest {
 		try {
 			new ProjectExplorer().getProject(projectName).getProjectItem(resourcePath).getProjectItem(fileName)
 					.openWith(textEditorType);
-		} catch (org.eclipse.reddeer.common.exception.WaitTimeoutExpiredException e) { // CRS need some time for
-																						// download microprofile...
-																						// when
-																						// application_properties
-																						// opens, sometimes it need
-																						// more then default 10
-																						// seconds
+		} catch (WaitTimeoutExpiredException e) { // CRS need some time for
+													// download microprofile...
+													// when
+													// application_properties
+													// opens, sometimes it need
+													// more then default 10
+													// seconds
 		}
 		new WaitWhile(new JobIsRunning(), TimePeriod.VERY_LONG);
 		return new TextEditor(fileName);


### PR DESCRIPTION
open file with text editor from AbstractCAtest to AbstractQuarkusTest

Signed-off-by: olkornii <olkornii@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
