### PR TITLE
JBIDE-28201: code completion/syntax validation is broken on hibernate…

### DIFF
--- a/features/org.jboss.tools.quarkus.feature/feature.xml
+++ b/features/org.jboss.tools.quarkus.feature/feature.xml
@@ -240,6 +240,7 @@ APPENDIX: How to apply the Apache License to your work.
    <requires>
       <import plugin="org.eclipse.lsp4mp.jdt.core"/>
       <import plugin="org.eclipse.lsp4e.jdt"/>
+      <import plugin="com.redhat.microprofile.jdt.quarkus"/>
       <import feature="org.eclipse.wildwebdeveloper.feature"/>
    </requires>
 


### PR DESCRIPTION
…-orm-quickstart

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
