### PR TITLE
JBIDE-28474: Label for excludes Qute templates setting is absent

### DIFF
--- a/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/internal/properties/qute/QuteConfigurationBlock.java
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/internal/properties/qute/QuteConfigurationBlock.java
@@ -149,6 +149,7 @@ public class QuteConfigurationBlock extends OptionsConfigurationBlock {
 		excludeList = new ListDialogField<>(adapter, buttons, new LabelProvider());
 		excludeList.setDialogFieldListener(adapter);
 		excludeList.setRemoveButtonIndex(2);
+		excludeList.setLabelText("Exclude from validation:");
 		createExcludeContent(mainComp);
 		String excludes = getStoredValue(QuarkusLSPPlugin.EXCLUDE_KEY);
 		if (excludes != null && excludes.length() > 0) {
@@ -172,7 +173,12 @@ public class QuteConfigurationBlock extends OptionsConfigurationBlock {
 		excludeComposite.setLayoutData(gd);
 		excludeComposite.setFont(folder.getFont());
 
-		GridData data= new GridData(GridData.FILL_BOTH);
+		GridData data= new GridData(GridData.FILL_HORIZONTAL);
+		data.horizontalSpan = 2;
+		Control labelControl = excludeList.getLabelControl(excludeComposite);
+		labelControl.setLayoutData(data);
+		
+		data= new GridData(GridData.FILL_BOTH);
 		data.widthHint= conv.convertWidthInCharsToPixels(50);
 		Control listControl= excludeList.getListControl(excludeComposite);
 		listControl.setLayoutData(data);


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
