### PR TITLE
JBIDE-28494: Can't open application.properties on Windows

### DIFF
--- a/plugins/org.jboss.tools.quarkus.lsp4e/plugin.xml
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/plugin.xml
@@ -135,11 +135,11 @@
          point="org.eclipse.tm4e.registry.grammars">
       <grammar
             path="language-support/properties-support/quarkus-properties.tmLanguage.json"
-            scopeName="properties">
+            scopeName="source.quarkus-properties">
       </grammar>
       <scopeNameContentTypeBinding
             contentTypeId="org.jboss.tools.quarkus.lsp4e.properties"
-            scopeName="properties">
+            scopeName="source.quarkus-properties">
       </scopeNameContentTypeBinding>
       <grammar
             path="language-support/qute/qute-html.tmLanguage.json"


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
