### PR TITLE
JBIDE-28715: Quarkus run configurations starts the Java debugger

### DIFF
--- a/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/tool/GradleToolSupport.java
+++ b/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/tool/GradleToolSupport.java
@@ -103,7 +103,7 @@ public class GradleToolSupport extends AbstractToolSupport {
 		Job job = Job.create("Starting " + context.getName(), monitor2 -> {
 			ILaunchConfigurationWorkingCopy launchConfiguration = getConfiguration(context);
 			launchConfiguration.setAttribute("tasks", Collections.singletonList("quarkusDev"));
-			List<String> arguments = add(launchConfiguration.getAttribute("arguments", Collections.emptyList()), "-Ddebug=" + context.getDebugPort());
+			List<String> arguments = add(launchConfiguration.getAttribute("arguments", Collections.emptyList()), "-Ddebug=" + getDebugArgument(context));
 			if (StringUtils.isNotBlank(context.getProfile())) {
 				arguments = add(arguments, "-Dquarkus.profile=" + context.getProfile());
 			}
@@ -123,5 +123,9 @@ public class GradleToolSupport extends AbstractToolSupport {
 		});
 		job.schedule();
 		return launch;
+	}
+
+	protected String getDebugArgument(ToolExecutionContext context) {
+		return context.isDebug()?Integer.toString(context.getDebugPort()):"false";
 	}
 }

--- a/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/tool/MavenToolSupport.java
+++ b/plugins/org.jboss.tools.quarkus.core/src/org/jboss/tools/quarkus/tool/MavenToolSupport.java
@@ -70,10 +70,14 @@ public class MavenToolSupport extends AbstractToolSupport {
 		ILaunchConfigurationWorkingCopy launchConfiguration = getConfiguration(context);
 		launchConfiguration.setAttribute(MavenLaunchConstants.ATTR_GOALS, "compile quarkus:dev");
 		if (StringUtils.isBlank(context.getProfile())) {
-			launchConfiguration.setAttribute(MavenLaunchConstants.ATTR_PROPERTIES, Collections.singletonList("debug=" + context.getDebugPort()));
+			launchConfiguration.setAttribute(MavenLaunchConstants.ATTR_PROPERTIES, Collections.singletonList("debug=" + getDebugArgument(context)));
 		} else {
-			launchConfiguration.setAttribute(MavenLaunchConstants.ATTR_PROPERTIES, Arrays.asList("debug=" + context.getDebugPort(), "quarkus.profile=" + context.getProfile()));
+			launchConfiguration.setAttribute(MavenLaunchConstants.ATTR_PROPERTIES, Arrays.asList("debug=" + getDebugArgument(context), "quarkus.profile=" + context.getProfile()));
 		}
 		return launchConfiguration.launch(ILaunchManager.RUN_MODE, monitor);
+	}
+
+	protected String getDebugArgument(ToolExecutionContext context) {
+		return context.isDebug()?Integer.toString(context.getDebugPort()):"false";
 	}
 }


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
