### PR TITLE
JBIDE-28730: Wrong editor opens while debugging quarkus project

### DIFF
--- a/plugins/org.jboss.tools.quarkus.core/plugin.xml
+++ b/plugins/org.jboss.tools.quarkus.core/plugin.xml
@@ -23,7 +23,8 @@
             delegate="org.jboss.tools.quarkus.core.launch.QuarkusLaunchConfigurationDelegate"
             id="org.jboss.tools.quarkus.core.launchConfigurationType"
             modes="run, debug"
-            name="Quarkus Application">
+            name="Quarkus Application"
+            sourceLocatorId="org.eclipse.jdt.launching.sourceLocator.JavaSourceLookupDirector">
       </launchConfigurationType>
    </extension>>
 </plugin>

--- a/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/launch/QuarkusLaunchConfigurationTabGroup.java
+++ b/plugins/org.jboss.tools.quarkus.ui/src/org/jboss/tools/quarkus/ui/launch/QuarkusLaunchConfigurationTabGroup.java
@@ -20,11 +20,12 @@ import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.CommonTab;
 import org.eclipse.debug.ui.EnvironmentTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
+import org.eclipse.debug.ui.sourcelookup.SourceLookupTab;
 
 public class QuarkusLaunchConfigurationTabGroup extends AbstractLaunchConfigurationTabGroup {
 
 	@Override
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-		setTabs(new QuarkusProjectTab(), new EnvironmentTab(), new CommonTab());
+		setTabs(new QuarkusProjectTab(), new SourceLookupTab(), new EnvironmentTab(), new CommonTab());
 	}
 }


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>

# Pull Request Checklist
## General
* Is this a blocking issue or new feature? If yes, QE needs to +1 this PR

## Code
* Are method-/class-/variable-names meaningful?
* Are methods concise, not too long?
* Are catch blocks catching precise Exceptions only (no catch all)?

## Testing
* Are there unit-tests?
* Are there integration tests (or at least a jira to tackle these)?
* Is the non-happy path working, too?
* Are other parts that use the same component still working fine?

## Function
* Does it work?
