### PR TITLE
Provide the capability to debug MicroProfile LS by settings the debug port 

### DIFF
--- a/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/QuarkusLanguageServer.java
+++ b/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/QuarkusLanguageServer.java
@@ -38,10 +38,13 @@ import org.jboss.tools.quarkus.core.QuarkusCoreUsageStats;
  *
  */
 public class QuarkusLanguageServer extends ProcessStreamConnectionProvider {
-
 	public QuarkusLanguageServer() {
 		List<String> commands = new ArrayList<>();
 		commands.add(computeJavaPath());
+		String debugPortString = System.getProperty(getClass().getName() + ".debugPort");
+		if (debugPortString != null) {
+			commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=" + debugPortString);
+		}
 		commands.add("-classpath");
 		try {
 			commands.add(computeClasspath());


### PR DESCRIPTION
debug port with system property like

`-Dorg.jboss.tools.quarkus.lsp4e.QuarkusLanguageServer.debugPort=1234`